### PR TITLE
MFR Integration: Fixed Crop Planting

### DIFF
--- a/java/com/pam/harvestcraft/PlantableMFRCrop.java
+++ b/java/com/pam/harvestcraft/PlantableMFRCrop.java
@@ -39,6 +39,11 @@ public class PlantableMFRCrop implements IFactoryPlantable
 	    @Override
 	    public void prePlant (World world, int x, int y, int z, ItemStack stack)
 	    {
+			Block ground = world.getBlock(x, y - 1, z);
+			if (ground.equals(Blocks.grass) || ground.equals(Blocks.dirt))
+			{
+				world.setBlock(x, y - 1, z, Blocks.farmland);
+			}
 	        return;
 	    }
 


### PR DESCRIPTION
Added Dirt/Grass -> Farmland conversion @ prePlant event

as this is the default behavior for the most (probably all?) Crops @ MFR-Planter.

For example see MFR's Vanilla Crop Handler:
https://github.com/skyboy/MineFactoryReloaded/blob/master/src/powercrystals/minefactoryreloaded/farmables/plantables/PlantableCropPlant.java#L35


