### PR TITLE
Fixing NPE on gardens being broken

### DIFF
--- a/java/com/pam/harvestcraft/Config.java
+++ b/java/com/pam/harvestcraft/Config.java
@@ -37,13 +37,19 @@ public class Config
 	public static final String CATEGORY_SEEDS = "seeds";
 	public static final String CATEGORY_MISC_RECIPES = "miscellaneous recipes";
 	
-	public void load(FMLPreInitializationEvent event)
-	{
-	Configuration config = new Configuration(event.getSuggestedConfigurationFile());
-	config.load();
-	BlockRegistry.initBlocks(event, config);
-	ItemRegistry.initItems(event, config);
+	public void load(FMLPreInitializationEvent event) {
+		Configuration config = new Configuration(event.getSuggestedConfigurationFile());
+		config.load();
+		BlockRegistry.initBlocks(event, config);
+		ItemRegistry.initItems(event, config);
+	}
 
+	/**
+	 * Configures drops from the various gardens; this needs to happen after the item registries are updated
+	 * @param event	The server's pre-init event
+     */
+	public void configureGardenDrops(FMLPreInitializationEvent event) {
+		Configuration config = new Configuration(event.getSuggestedConfigurationFile());
 		final Pattern ITEM_STACK_PATTERN = Pattern.compile("(?:([0-9]+)x)?([\\w:]+)(?:[@:]([0-9]+))?");
 		final Matcher ITEM_STACK_MATCHER = ITEM_STACK_PATTERN.matcher("");
 		 

--- a/java/com/pam/harvestcraft/Config.java
+++ b/java/com/pam/harvestcraft/Config.java
@@ -1,23 +1,18 @@
 package com.pam.harvestcraft;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import com.google.common.collect.Lists;
-import com.pam.harvestcraft.blocks.AridGardenBlock;
-import com.pam.harvestcraft.blocks.BlockRegistry;
-import com.pam.harvestcraft.blocks.FrostGardenBlock;
-import com.pam.harvestcraft.blocks.ShadedGardenBlock;
-import com.pam.harvestcraft.blocks.SoggyGardenBlock;
-import com.pam.harvestcraft.blocks.TropicalGardenBlock;
-import com.pam.harvestcraft.blocks.WindyGardenBlock;
+import com.pam.harvestcraft.blocks.*;
 import com.pam.harvestcraft.item.ItemRegistry;
 
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.common.config.Configuration;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
-import net.minecraftforge.fml.common.registry.GameData;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 
 public class Config 
@@ -36,187 +31,95 @@ public class Config
 	public static final String CATEGORY_DIMENSIONS = "dimensions";
 	public static final String CATEGORY_SEEDS = "seeds";
 	public static final String CATEGORY_MISC_RECIPES = "miscellaneous recipes";
+
+	private Map<String, String[]> dropConfig = new HashMap<String, String[]>();
 	
 	public void load(FMLPreInitializationEvent event) {
 		Configuration config = new Configuration(event.getSuggestedConfigurationFile());
 		config.load();
 		BlockRegistry.initBlocks(event, config);
 		ItemRegistry.initItems(event, config);
+
+		dropConfig.put("aridGarden", config.getStringList("aridGarden", "drops",
+				new String[]{"harvestcraft:cactusfruitItem"},
+				"comment"));
+		dropConfig.put("frostGarden", config.getStringList("frostGarden", "drops",
+				new String[]{"harvestcraft:raspberryItem", "harvestcraft:oatsItem", "harvestcraft:ryeItem",
+						"harvestcraft:celeryItem", "harvestcraft:peasItem", "harvestcraft:beetItem",
+						"harvestcraft:rutabagaItem", "harvestcraft:broccoliItem", "harvestcraft:cauliflowerItem",
+						"harvestcraft:cabbageItem", "harvestcraft:spinachItem"},
+				"comment"));
+		dropConfig.put("shadedGarden", config.getStringList("shadedGarden", "drops",
+				new String[]{"harvestcraft:whitemushroomItem", "harvestcraft:blackberryItem", "harvestcraft:zucchiniItem",
+						"harvestcraft:radishItem", "harvestcraft:rhubarbItem", "harvestcraft:tealeafItem",
+						"harvestcraft:garlicItem", "harvestcraft:sweetpotatoItem", "harvestcraft:turnipItem",
+						"harvestcraft:spiceleafItem", "harvestcraft:beanItem", "harvestcraft:leekItem",
+						"harvestcraft:scallionItem", "harvestcraft:tomatoItem"},
+				"comment"));
+		dropConfig.put("soggyGarden", config.getStringList("soggyGarden", "drops",
+				new String[]{"harvestcraft:brusselsproutItem", "harvestcraft:spiceleafItem", "harvestcraft:blueberryItem",
+						"harvestcraft:asparagusItem", "harvestcraft:cranberryItem", "harvestcraft:riceItem",
+						"harvestcraft:seaweedItem", "harvestcraft:waterchestnutItem", "harvestcraft:okraItem"},
+				"comment"));
+		dropConfig.put("tropicalGarden", config.getStringList("tropicalGarden", "drops",
+				new String[]{"harvestcraft:grapeItem", "harvestcraft:pineappleItem", "harvestcraft:kiwiItem",
+						"harvestcraft:sesameseedsItem", "harvestcraft:curryleafItem", "harvestcraft:bambooshootItem",
+						"harvestcraft:cantaloupeItem", "harvestcraft:gingerItem", "harvestcraft:coffeebeanItem",
+						"harvestcraft:soybeanItem", "harvestcraft:eggplantItem"},
+				"comment"));
+		dropConfig.put("windyGarden", config.getStringList("windyGarden", "drops",
+				new String[]{"harvestcraft:strawberryItem", "harvestcraft:barleyItem", "harvestcraft:cornItem",
+						"harvestcraft:cucumberItem", "harvestcraft:wintersquashItem", "harvestcraft:mustardseedsItem",
+						"harvestcraft:onionItem", "harvestcraft:parsnipItem", "harvestcraft:peanutItem",
+						"minecraft:potato", "minecraft:carrot", "harvestcraft:lettuceItem",
+						"harvestcraft:artichokeItem", "harvestcraft:bellpepperItem", "harvestcraft:chilipepperItem",
+						"minecraft:wheat",},
+				"comment"));
+
+		if (config.hasChanged())
+		{
+			config.save();
+		}
 	}
 
 	/**
 	 * Configures drops from the various gardens; this needs to happen after the item registries are updated
-	 * @param event	The server's pre-init event
      */
-	public void configureGardenDrops(FMLPreInitializationEvent event) {
-		Configuration config = new Configuration(event.getSuggestedConfigurationFile());
+	public void configureGardenDrops() {
 		final Pattern ITEM_STACK_PATTERN = Pattern.compile("(?:([0-9]+)x)?([\\w:]+)(?:[@:]([0-9]+))?");
 		final Matcher ITEM_STACK_MATCHER = ITEM_STACK_PATTERN.matcher("");
-		 
-		String[] aridGardenDropEntries = config.getStringList("aridGarden", "drops", 
-				new String[] { "harvestcraft:cactusfruitItem"}, 
-							"comment");
-		ItemStack[] aridGardenDrops = new ItemStack[aridGardenDropEntries.length];
-		for(int i = 0; i < aridGardenDrops.length; i++) 
-		{
-		    ITEM_STACK_MATCHER.reset(aridGardenDropEntries[i]);
-		    if(ITEM_STACK_MATCHER.find()) {
-		        String itemName = ITEM_STACK_MATCHER.group(2);
-		        int metadata = 0;
-		        if(ITEM_STACK_MATCHER.group(3) != null) {
-		            metadata = Integer.parseInt(ITEM_STACK_MATCHER.group(3));
-		        }
-		        int stackSize = 1;
-		        if(ITEM_STACK_MATCHER.group(1) != null) {
-		            stackSize = Integer.parseInt(ITEM_STACK_MATCHER.group(1));
-		        }
-		        aridGardenDrops[i] = GameRegistry.makeItemStack(itemName, metadata, stackSize, null);
 
-		    }
-		   
-		}
-		 AridGardenBlock.drops = Lists.newArrayList(aridGardenDrops);
-		 
-		 String[] frostGardenDropEntries = config.getStringList("frostGarden", "drops", 
-					new String[] { "harvestcraft:raspberryItem","harvestcraft:oatsItem","harvestcraft:ryeItem",
-							"harvestcraft:celeryItem","harvestcraft:peasItem","harvestcraft:beetItem",
-							"harvestcraft:rutabagaItem","harvestcraft:broccoliItem","harvestcraft:cauliflowerItem",
-							"harvestcraft:cabbageItem","harvestcraft:spinachItem"}, 
-								"comment");
-			ItemStack[] frostGardenDrops = new ItemStack[frostGardenDropEntries.length];
-			for(int i = 0; i < frostGardenDrops.length; i++) 
-			{
-			    ITEM_STACK_MATCHER.reset(frostGardenDropEntries[i]);
-			    if(ITEM_STACK_MATCHER.find()) {
-			        String itemName = ITEM_STACK_MATCHER.group(2);
-			        int metadata = 0;
-			        if(ITEM_STACK_MATCHER.group(3) != null) {
-			            metadata = Integer.parseInt(ITEM_STACK_MATCHER.group(3));
-			        }
-			        int stackSize = 1;
-			        if(ITEM_STACK_MATCHER.group(1) != null) {
-			            stackSize = Integer.parseInt(ITEM_STACK_MATCHER.group(1));
-			        }
-			        frostGardenDrops[i] = GameRegistry.makeItemStack(itemName, metadata, stackSize, null);
+		for(String garden : dropConfig.keySet()) {
+			System.out.println("Registering drops for '" + garden + "'.");
 
-			    }
-			   
-			}
-			 FrostGardenBlock.drops = Lists.newArrayList(frostGardenDrops);
-			 
-			 String[] shadedGardenDropEntries = config.getStringList("shadedGarden", "drops", 
-						new String[] { "harvestcraft:whitemushroomItem","harvestcraft:blackberryItem","harvestcraft:zucchiniItem",
-								"harvestcraft:radishItem","harvestcraft:rhubarbItem","harvestcraft:tealeafItem",
-								"harvestcraft:garlicItem","harvestcraft:sweetpotatoItem","harvestcraft:turnipItem",
-								"harvestcraft:spiceleafItem","harvestcraft:beanItem","harvestcraft:leekItem",
-								"harvestcraft:scallionItem","harvestcraft:tomatoItem"}, 
-									"comment");
-				ItemStack[] shadedGardenDrops = new ItemStack[shadedGardenDropEntries.length];
-				for(int i = 0; i < shadedGardenDrops.length; i++) 
-				{
-				    ITEM_STACK_MATCHER.reset(shadedGardenDropEntries[i]);
-				    if(ITEM_STACK_MATCHER.find()) {
-				        String itemName = ITEM_STACK_MATCHER.group(2);
-				        int metadata = 0;
-				        if(ITEM_STACK_MATCHER.group(3) != null) {
-				            metadata = Integer.parseInt(ITEM_STACK_MATCHER.group(3));
-				        }
-				        int stackSize = 1;
-				        if(ITEM_STACK_MATCHER.group(1) != null) {
-				            stackSize = Integer.parseInt(ITEM_STACK_MATCHER.group(1));
-				        }
-				        shadedGardenDrops[i] = GameRegistry.makeItemStack(itemName, metadata, stackSize, null);
+			List<ItemStack> drops = new ArrayList<ItemStack>();
+			String[] itemNames = dropConfig.get(garden);
 
-				    }
-				   
-				}
-				 ShadedGardenBlock.drops = Lists.newArrayList(shadedGardenDrops);
-				 
-				 String[] soggyGardenDropEntries = config.getStringList("soggyGarden", "drops", 
-							new String[] { "harvestcraft:brusselsproutItem","harvestcraft:spiceleafItem","harvestcraft:blueberryItem",
-									"harvestcraft:asparagusItem","harvestcraft:cranberryItem","harvestcraft:riceItem",
-									"harvestcraft:seaweedItem","harvestcraft:waterchestnutItem","harvestcraft:okraItem"}, 
-										"comment");
-					ItemStack[] soggyGardenDrops = new ItemStack[soggyGardenDropEntries.length];
-					for(int i = 0; i < soggyGardenDrops.length; i++) 
-					{
-					    ITEM_STACK_MATCHER.reset(soggyGardenDropEntries[i]);
-					    if(ITEM_STACK_MATCHER.find()) {
-					        String itemName = ITEM_STACK_MATCHER.group(2);
-					        int metadata = 0;
-					        if(ITEM_STACK_MATCHER.group(3) != null) {
-					            metadata = Integer.parseInt(ITEM_STACK_MATCHER.group(3));
-					        }
-					        int stackSize = 1;
-					        if(ITEM_STACK_MATCHER.group(1) != null) {
-					            stackSize = Integer.parseInt(ITEM_STACK_MATCHER.group(1));
-					        }
-					        soggyGardenDrops[i] = GameRegistry.makeItemStack(itemName, metadata, stackSize, null);
-
-					    }
-					   
+			for(String baseItemName : itemNames) {
+				ITEM_STACK_MATCHER.reset(baseItemName);
+				if(ITEM_STACK_MATCHER.find()) {
+					String itemName = ITEM_STACK_MATCHER.group(2);
+					int metadata = 0;
+					if(ITEM_STACK_MATCHER.group(3) != null) {
+						metadata = Integer.parseInt(ITEM_STACK_MATCHER.group(3));
 					}
-					 SoggyGardenBlock.drops = Lists.newArrayList(soggyGardenDrops);
-					 
-					 String[] tropicalGardenDropEntries = config.getStringList("tropicalGarden", "drops", 
-								new String[] { "harvestcraft:grapeItem","harvestcraft:pineappleItem","harvestcraft:kiwiItem",
-										"harvestcraft:sesameseedsItem","harvestcraft:curryleafItem","harvestcraft:bambooshootItem",
-										"harvestcraft:cantaloupeItem","harvestcraft:gingerItem","harvestcraft:coffeebeanItem",
-										"harvestcraft:soybeanItem","harvestcraft:eggplantItem"}, 
-											"comment");
-						ItemStack[] tropicalGardenDrops = new ItemStack[tropicalGardenDropEntries.length];
-						for(int i = 0; i < tropicalGardenDrops.length; i++) 
-						{
-						    ITEM_STACK_MATCHER.reset(tropicalGardenDropEntries[i]);
-						    if(ITEM_STACK_MATCHER.find()) {
-						        String itemName = ITEM_STACK_MATCHER.group(2);
-						        int metadata = 0;
-						        if(ITEM_STACK_MATCHER.group(3) != null) {
-						            metadata = Integer.parseInt(ITEM_STACK_MATCHER.group(3));
-						        }
-						        int stackSize = 1;
-						        if(ITEM_STACK_MATCHER.group(1) != null) {
-						            stackSize = Integer.parseInt(ITEM_STACK_MATCHER.group(1));
-						        }
-						        tropicalGardenDrops[i] = GameRegistry.makeItemStack(itemName, metadata, stackSize, null);
+					int stackSize = 1;
+					if(ITEM_STACK_MATCHER.group(1) != null) {
+						stackSize = Integer.parseInt(ITEM_STACK_MATCHER.group(1));
+					}
+					ItemStack drop = GameRegistry.makeItemStack(itemName, metadata, stackSize, null);
 
-						    }
-						   
-						}
-						 TropicalGardenBlock.drops = Lists.newArrayList(tropicalGardenDrops);
-						 
-						 String[] windyGardenDropEntries = config.getStringList("windyGarden", "drops", 
-									new String[] { "harvestcraft:strawberryItem","harvestcraft:barleyItem","harvestcraft:cornItem",
-											"harvestcraft:cucumberItem","harvestcraft:wintersquashItem","harvestcraft:mustardseedsItem",
-											"harvestcraft:onionItem","harvestcraft:parsnipItem","harvestcraft:peanutItem",
-											"minecraft:potato","minecraft:carrot","harvestcraft:lettuceItem",
-											"harvestcraft:artichokeItem","harvestcraft:bellpepperItem","harvestcraft:chilipepperItem",
-											"minecraft:wheat",}, 
-												"comment");
-							ItemStack[] windyGardenDrops = new ItemStack[windyGardenDropEntries.length];
-							for(int i = 0; i < windyGardenDrops.length; i++) 
-							{
-							    ITEM_STACK_MATCHER.reset(windyGardenDropEntries[i]);
-							    if(ITEM_STACK_MATCHER.find()) {
-							        String itemName = ITEM_STACK_MATCHER.group(2);
-							        int metadata = 0;
-							        if(ITEM_STACK_MATCHER.group(3) != null) {
-							            metadata = Integer.parseInt(ITEM_STACK_MATCHER.group(3));
-							        }
-							        int stackSize = 1;
-							        if(ITEM_STACK_MATCHER.group(1) != null) {
-							            stackSize = Integer.parseInt(ITEM_STACK_MATCHER.group(1));
-							        }
-							        windyGardenDrops[i] = GameRegistry.makeItemStack(itemName, metadata, stackSize, null);
+					// Check to make sure we got a valid item
+					if(drop != null) {
+						drops.add(drop);
+					} else {
+						// Otherwise, let the user know about it...
+						System.err.println("Unable to find item '" + baseItemName + "' to add to this garden.");
+					}
+				}
+			}
 
-							    }
-							   
-							}
-							 WindyGardenBlock.drops = Lists.newArrayList(windyGardenDrops);
-		
-		if (config.hasChanged())
-		{
-			config.save();
+			BlockBaseGarden.drops.put(garden, drops);
 		}
 	}
 }

--- a/java/com/pam/harvestcraft/blocks/AridGardenBlock.java
+++ b/java/com/pam/harvestcraft/blocks/AridGardenBlock.java
@@ -24,14 +24,13 @@ import net.minecraftforge.fml.common.registry.GameRegistry;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-public class AridGardenBlock extends BlockBush
+public class AridGardenBlock extends BlockBaseGarden
 {
 	private final String name = "aridgarden";
-	public static List<ItemStack> drops;
-	
+
 	public AridGardenBlock()
 	{	
-		super(Material.grass);
+		super("aridGarden", Material.grass);
 		GameRegistry.registerBlock(this, name);
 		setUnlocalizedName(name);
 		setCreativeTab(harvestcraft.modTab);
@@ -41,16 +40,6 @@ public class AridGardenBlock extends BlockBush
     //public void initModel() {
     //    ModelLoader.setCustomModelResourceLocation(Item.getItemFromBlock(this), 0, new ModelResourceLocation(getRegistryName(), "inventory"));
     //}
-
-	public List<ItemStack> getDrops(IBlockAccess world, BlockPos pos, IBlockState state, int fortune)
-	{
-	    List<ItemStack> newStack = new ArrayList<ItemStack>();
-	    Collections.shuffle(drops);
-	    for (int i = 0; i < Math.min(BlockRegistry.gardendropAmount, drops.size()); i++) {
-	        newStack.add(drops.get(i).copy());
-	    }
-	    return newStack;
-	}
 	
 	@Override
 	protected boolean canPlaceBlockOn(Block ground)

--- a/java/com/pam/harvestcraft/blocks/BlockBaseGarden.java
+++ b/java/com/pam/harvestcraft/blocks/BlockBaseGarden.java
@@ -1,0 +1,48 @@
+package com.pam.harvestcraft.blocks;
+
+import net.minecraft.block.BlockBush;
+import net.minecraft.block.material.Material;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.BlockPos;
+import net.minecraft.world.IBlockAccess;
+
+import java.util.*;
+
+/**
+ * Created by Matt on 4/8/2016.
+ */
+public abstract class BlockBaseGarden extends BlockBush {
+    public static Map<String, List<ItemStack>> drops = new HashMap<String, List<ItemStack>>();
+    private final String type;
+
+    public BlockBaseGarden(String type, Material grass) {
+        super(grass);
+        this.type = type;
+    }
+
+    public List<ItemStack> getDrops(IBlockAccess world, BlockPos pos, IBlockState state, int fortune)
+    {
+        List<ItemStack> newStack = new ArrayList<ItemStack>();
+        List<ItemStack> ourDrops = drops.get(type);
+        Collections.shuffle(ourDrops);
+
+        // Optimize so we're not calling this every time through the for loop...
+        int len = Math.min(BlockRegistry.gardendropAmount, ourDrops.size());
+
+        for (int i = 0; i < len; i++) {
+            ItemStack drop = ourDrops.get(i);
+
+            // This should never happen, but check it anyway...
+            if(drop == null) {
+                System.err.println("Tried to get a null item for garden '" + type + "'.");
+                continue;
+            }
+
+            // Add it to our drops...
+            newStack.add(drop.copy());
+        }
+        return newStack;
+    }
+
+}

--- a/java/com/pam/harvestcraft/blocks/FrostGardenBlock.java
+++ b/java/com/pam/harvestcraft/blocks/FrostGardenBlock.java
@@ -19,27 +19,17 @@ import net.minecraft.util.BlockPos;
 import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 
-public class FrostGardenBlock extends BlockBush
+public class FrostGardenBlock extends BlockBaseGarden
 {
 	private final String name = "frostgarden";
 	public static List<ItemStack> drops;
 	
 	public FrostGardenBlock()
 	{	
-		super(Material.grass);
+		super("frostGarden", Material.grass);
 		GameRegistry.registerBlock(this, name);
 		setUnlocalizedName(name);
 		setCreativeTab(harvestcraft.modTab);
-	}
-
-	public List<ItemStack> getDrops(IBlockAccess world, BlockPos pos, IBlockState state, int fortune)
-	{
-	    List<ItemStack> newStack = new ArrayList<ItemStack>();
-	    Collections.shuffle(drops);
-	    for (int i = 0; i < Math.min(BlockRegistry.gardendropAmount, drops.size()); i++) {
-	        newStack.add(drops.get(i).copy());
-	    }
-	    return newStack;
 	}
 	
 	@Override

--- a/java/com/pam/harvestcraft/blocks/ShadedGardenBlock.java
+++ b/java/com/pam/harvestcraft/blocks/ShadedGardenBlock.java
@@ -19,27 +19,17 @@ import net.minecraft.util.BlockPos;
 import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 
-public class ShadedGardenBlock extends BlockBush
+public class ShadedGardenBlock extends BlockBaseGarden
 {
 	private final String name = "shadedgarden";
 	public static List<ItemStack> drops;
 	
 	public ShadedGardenBlock()
 	{	
-		super(Material.grass);
+		super("shadedGarden", Material.grass);
 		GameRegistry.registerBlock(this, name);
 		setUnlocalizedName(name);
 		setCreativeTab(harvestcraft.modTab);
-	}
-
-	public List<ItemStack> getDrops(IBlockAccess world, BlockPos pos, IBlockState state, int fortune)
-	{
-	    List<ItemStack> newStack = new ArrayList<ItemStack>();
-	    Collections.shuffle(drops);
-	    for (int i = 0; i < Math.min(BlockRegistry.gardendropAmount, drops.size()); i++) {
-	        newStack.add(drops.get(i).copy());
-	    }
-	    return newStack;
 	}
 	
 	@Override

--- a/java/com/pam/harvestcraft/blocks/SoggyGardenBlock.java
+++ b/java/com/pam/harvestcraft/blocks/SoggyGardenBlock.java
@@ -19,27 +19,17 @@ import net.minecraft.util.BlockPos;
 import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 
-public class SoggyGardenBlock extends BlockBush
+public class SoggyGardenBlock extends BlockBaseGarden
 {
 	private final String name = "soggygarden";
 	public static List<ItemStack> drops;
 	
 	public SoggyGardenBlock()
 	{	
-		super(Material.grass);
+		super("soggyGarden", Material.grass);
 		GameRegistry.registerBlock(this, name);
 		setUnlocalizedName(name);
 		setCreativeTab(harvestcraft.modTab);
-	}
-
-	public List<ItemStack> getDrops(IBlockAccess world, BlockPos pos, IBlockState state, int fortune)
-	{
-	    List<ItemStack> newStack = new ArrayList<ItemStack>();
-	    Collections.shuffle(drops);
-	    for (int i = 0; i < Math.min(BlockRegistry.gardendropAmount, drops.size()); i++) {
-	        newStack.add(drops.get(i).copy());
-	    }
-	    return newStack;
 	}
 	
 	@Override

--- a/java/com/pam/harvestcraft/blocks/TropicalGardenBlock.java
+++ b/java/com/pam/harvestcraft/blocks/TropicalGardenBlock.java
@@ -19,27 +19,17 @@ import net.minecraft.util.BlockPos;
 import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 
-public class TropicalGardenBlock extends BlockBush
+public class TropicalGardenBlock extends BlockBaseGarden
 {
 	private final String name = "tropicalgarden";
 	public static List<ItemStack> drops;
 	
 	public TropicalGardenBlock()
 	{	
-		super(Material.grass);
+		super("tropicalGarden", Material.grass);
 		GameRegistry.registerBlock(this, name);
 		setUnlocalizedName(name);
 		setCreativeTab(harvestcraft.modTab);
-	}
-
-	public List<ItemStack> getDrops(IBlockAccess world, BlockPos pos, IBlockState state, int fortune)
-	{
-	    List<ItemStack> newStack = new ArrayList<ItemStack>();
-	    Collections.shuffle(drops);
-	    for (int i = 0; i < Math.min(BlockRegistry.gardendropAmount, drops.size()); i++) {
-	        newStack.add(drops.get(i).copy());
-	    }
-	    return newStack;
 	}
 	
 	@Override

--- a/java/com/pam/harvestcraft/blocks/WindyGardenBlock.java
+++ b/java/com/pam/harvestcraft/blocks/WindyGardenBlock.java
@@ -19,27 +19,17 @@ import net.minecraft.util.BlockPos;
 import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 
-public class WindyGardenBlock extends BlockBush
+public class WindyGardenBlock extends BlockBaseGarden
 {
 	private final String name = "windygarden";
 	public static List<ItemStack> drops;
 	
 	public WindyGardenBlock()
 	{	
-		super(Material.grass);
+		super("windyGarden", Material.grass);
 		GameRegistry.registerBlock(this, name);
 		setUnlocalizedName(name);
 		setCreativeTab(harvestcraft.modTab);
-	}
-	
-	public List<ItemStack> getDrops(IBlockAccess world, BlockPos pos, IBlockState state, int fortune)
-	{
-	    List<ItemStack> newStack = new ArrayList<ItemStack>();
-	    Collections.shuffle(drops);
-	    for (int i = 0; i < Math.min(BlockRegistry.gardendropAmount, drops.size()); i++) {
-	        newStack.add(drops.get(i).copy());
-	    }
-	    return newStack;
 	}
 	
 	@Override

--- a/java/com/pam/harvestcraft/harvestcraft.java
+++ b/java/com/pam/harvestcraft/harvestcraft.java
@@ -48,9 +48,9 @@ public class harvestcraft {
 
     @EventHandler
     public void preInit(FMLPreInitializationEvent event) {
-    	Config.instance.load(event);
     	this.proxy.preInit(event);
-    	
+        Config.instance.load(event);
+
         PamFoodRecipes.getRecipes();
         PamOtherRecipes.getRecipes();
         PamFoodOreDictionaryRegistry.getRegistry();

--- a/java/com/pam/harvestcraft/harvestcraft.java
+++ b/java/com/pam/harvestcraft/harvestcraft.java
@@ -48,8 +48,9 @@ public class harvestcraft {
 
     @EventHandler
     public void preInit(FMLPreInitializationEvent event) {
-    	this.proxy.preInit(event);
         Config.instance.load(event);
+    	this.proxy.preInit(event);
+        Config.instance.configureGardenDrops(event);
 
         PamFoodRecipes.getRecipes();
         PamOtherRecipes.getRecipes();

--- a/java/com/pam/harvestcraft/harvestcraft.java
+++ b/java/com/pam/harvestcraft/harvestcraft.java
@@ -50,7 +50,7 @@ public class harvestcraft {
     public void preInit(FMLPreInitializationEvent event) {
         Config.instance.load(event);
     	this.proxy.preInit(event);
-        Config.instance.configureGardenDrops(event);
+        Config.instance.configureGardenDrops();
 
         PamFoodRecipes.getRecipes();
         PamOtherRecipes.getRecipes();


### PR DESCRIPTION
The drop table for bushes was loaded before proxy.preInit ran, which actually registered the items to be dropped, thus, the entire drop table was null.