### PR TITLE
Fix worldgen loading new chunks, improve performance of worldgen feature placement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ build
 # other
 eclipse
 run
+
+classes/
+libs/

--- a/src/main/java/com/pam/harvestcraft/blocks/blocks/BlockBaseGarden.java
+++ b/src/main/java/com/pam/harvestcraft/blocks/blocks/BlockBaseGarden.java
@@ -11,6 +11,7 @@ import java.util.Random;
 
 import com.pam.harvestcraft.HarvestCraft;
 import com.pam.harvestcraft.blocks.BlockRegistry;
+import com.pam.harvestcraft.worldgen.WorldGenHelper;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockBush;
@@ -81,7 +82,7 @@ public class BlockBaseGarden extends BlockBush {
             int amount = config.gardenSpreadMax;
 
             for (BlockPos blockpos : BlockPos.getAllInBoxMutable(pos.add(-4, -1, -4), pos.add(4, 1, 4))) {
-                if (worldIn.getBlockState(blockpos).getBlock() == this) {
+                if (!worldIn.isBlockLoaded(blockpos) || worldIn.getBlockState(blockpos).getBlock() == this) {
                     --amount;
 
                     if (amount <= 0) return;
@@ -91,14 +92,15 @@ public class BlockBaseGarden extends BlockBush {
             BlockPos newGardenPos = pos.add(rand.nextInt(3) - 1, rand.nextInt(2) - rand.nextInt(2), rand.nextInt(3) - 1);
 
             for (int k = 0; k < 4; ++k) {
-                if (worldIn.isAirBlock(newGardenPos) && canBlockStay(worldIn, newGardenPos, getDefaultState())) {
+                if (worldIn.isBlockLoaded(newGardenPos) && canPlaceBlockAt(worldIn, newGardenPos) && canBlockStay(worldIn, newGardenPos, getDefaultState())) {
                     pos = newGardenPos;
                 }
 
                 newGardenPos = pos.add(rand.nextInt(3) - 1, rand.nextInt(2) - rand.nextInt(2), rand.nextInt(3) - 1);
             }
 
-            if (worldIn.isAirBlock(newGardenPos) &&
+            if (worldIn.isBlockLoaded(newGardenPos) &&
+                    canPlaceBlockAt(worldIn, newGardenPos) &&
                     canBlockStay(worldIn, newGardenPos, getDefaultState())) {
                 worldIn.setBlockState(newGardenPos, getDefaultState(), 2);
             }
@@ -107,7 +109,8 @@ public class BlockBaseGarden extends BlockBush {
 
     @Override
     public boolean canPlaceBlockAt(World worldIn, BlockPos pos) {
-        return worldIn.isAirBlock(pos) && checkSoilBlock(worldIn, pos);
+        IBlockState blockState = worldIn.getBlockState(pos);
+        return WorldGenHelper.canReplace(blockState, worldIn, pos) && checkSoilBlock(worldIn, pos);
     }
 
     private boolean checkSoilBlock(World world, BlockPos pos) {

--- a/src/main/java/com/pam/harvestcraft/blocks/growables/BlockPamSapling.java
+++ b/src/main/java/com/pam/harvestcraft/blocks/growables/BlockPamSapling.java
@@ -7,6 +7,7 @@ import javax.annotation.Nonnull;
 import com.pam.harvestcraft.HarvestCraft;
 import com.pam.harvestcraft.worldgen.FruitTreeGen;
 import com.pam.harvestcraft.worldgen.LogFruitTreeGen;
+import com.pam.harvestcraft.worldgen.WorldGenHelper;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockBush;
@@ -147,20 +148,18 @@ public class BlockPamSapling extends BlockBush implements IGrowable {
         }
     }
 
-    public void worldGenTrees(World world, BlockPos pos) {
-        for (int tries = 0; tries < rarity; tries++) {
-            int posX = pos.getX() + world.rand.nextInt(8) - world.rand.nextInt(8);
-            int posY = pos.getY() + world.rand.nextInt(4) - world.rand.nextInt(4);
-            int posZ = pos.getZ() + world.rand.nextInt(8) - world.rand.nextInt(8);
-            final BlockPos newPos = new BlockPos(posX, posY, posZ);
+    public void worldGenTree(World world, Random random, int x, int z) {
+        if (random.nextFloat() > rarity / 64.0f) return;
 
-            final IBlockState fruitState = getFruit().getDefaultState();
+        final BlockPos pos = WorldGenHelper.getGroundPos(world, x, z);
+        if (pos == null) return;
 
-            if (getFruit() instanceof BlockPamFruit) {
-                new FruitTreeGen(5, logState, leavesState, false, fruitState).generate(world, world.rand, newPos);
-            } else if (getFruit() instanceof BlockPamFruitLog) {
-                new LogFruitTreeGen(5, logState, leavesState, fruitState).generate(world, world.rand, newPos);
-            }
+        final IBlockState fruitState = getFruit().getDefaultState();
+
+        if (getFruit() instanceof BlockPamFruit) {
+            new FruitTreeGen(5, logState, leavesState, false, fruitState).generate(world, random, pos);
+        } else if (getFruit() instanceof BlockPamFruitLog) {
+            new LogFruitTreeGen(5, logState, leavesState, fruitState).generate(world, random, pos);
         }
     }
 

--- a/src/main/java/com/pam/harvestcraft/tileentities/TileEntityApiary.java
+++ b/src/main/java/com/pam/harvestcraft/tileentities/TileEntityApiary.java
@@ -173,8 +173,9 @@ public class TileEntityApiary extends TileEntity implements ITickable {
 						|| offsetX == radius - 1 && offsetZ == -radius - 1
 						|| offsetX == -radius - 1 && offsetZ == radius - 1)
 					continue;
-				final Block blockAtCoords =
-						world.getBlockState(new BlockPos(varX + offsetX, varY, varZ + offsetZ)).getBlock();
+				final BlockPos pos = new BlockPos(varX + offsetX, varY, varZ + offsetZ);
+				if (!world.isBlockLoaded(pos)) continue;
+				final Block blockAtCoords = world.getBlockState(pos).getBlock();
 				if(blockAtCoords instanceof BlockFlower || blockAtCoords instanceof BlockCrops
 						|| blockAtCoords instanceof BlockBaseGarden) {
 					speed = (int) (speed * 0.95);

--- a/src/main/java/com/pam/harvestcraft/tileentities/TileEntityGroundTrap.java
+++ b/src/main/java/com/pam/harvestcraft/tileentities/TileEntityGroundTrap.java
@@ -80,8 +80,9 @@ public class TileEntityGroundTrap extends TileEntity implements ITickable {
 						&& (offsetX != radius - 1 || offsetZ != radius - 1)
 						&& (offsetX != radius - 1 || offsetZ != -(radius - 1))
 						&& (offsetX != -(radius - 1) || offsetZ != radius - 1)) {
-					final Block blockAtCoords =
-							world.getBlockState(new BlockPos(varX + offsetX, varY, varZ + offsetZ)).getBlock();
+					final BlockPos pos = new BlockPos(varX + offsetX, varY, varZ + offsetZ);
+					if (!world.isBlockLoaded(pos)) continue;
+					final Block blockAtCoords = world.getBlockState(pos).getBlock();
 					if(blockAtCoords instanceof BlockDirt || blockAtCoords instanceof BlockGrass) {
 						count++;
 					}
@@ -281,8 +282,9 @@ public class TileEntityGroundTrap extends TileEntity implements ITickable {
 						|| offsetX == radius - 1 && offsetZ == -radius - 1
 						|| offsetX == -radius - 1 && offsetZ == radius - 1)
 					continue;
-				final Block blockAtCoords =
-						world.getBlockState(new BlockPos(varX + offsetX, varY, varZ + offsetZ)).getBlock();
+				final BlockPos pos = new BlockPos(varX + offsetX, varY, varZ + offsetZ);
+				if (!world.isBlockLoaded(pos)) continue;
+				final Block blockAtCoords = world.getBlockState(pos).getBlock();
 				if(blockAtCoords instanceof BlockDirt || blockAtCoords instanceof BlockGrass) {
 					speed = (int) (speed * 0.95);
 				}

--- a/src/main/java/com/pam/harvestcraft/tileentities/TileEntityWaterTrap.java
+++ b/src/main/java/com/pam/harvestcraft/tileentities/TileEntityWaterTrap.java
@@ -78,8 +78,8 @@ public class TileEntityWaterTrap extends TileEntity implements ITickable {
 						&& (offsetX != radius - 1 || offsetZ != radius - 1)
 						&& (offsetX != radius - 1 || offsetZ != -(radius - 1))
 						&& (offsetX != -(radius - 1) || offsetZ != radius - 1)) {
-					if(world.getBlockState(new BlockPos(varX + offsetX, varY, varZ + offsetZ))
-							.getBlock() == Blocks.WATER) {
+					final BlockPos pos = new BlockPos(varX + offsetX, varY, varZ + offsetZ);
+					if (world.isBlockLoaded(pos) && world.getBlockState(pos).getBlock() == Blocks.WATER) {
 						count++;
 					}
 				}
@@ -261,8 +261,9 @@ public class TileEntityWaterTrap extends TileEntity implements ITickable {
 						|| offsetX == radius - 1 && offsetZ == -radius - 1
 						|| offsetX == -radius - 1 && offsetZ == radius - 1)
 					continue;
-				final Block blockAtCoords =
-						world.getBlockState(new BlockPos(varX + offsetX, varY, varZ + offsetZ)).getBlock();
+				final BlockPos pos = new BlockPos(varX + offsetX, varY, varZ + offsetZ);
+				if (!world.isBlockLoaded(pos)) continue;
+				final Block blockAtCoords = world.getBlockState(pos).getBlock();
 				if(blockAtCoords instanceof BlockLiquid) {
 					speed = (int) (speed * 0.95);
 				}

--- a/src/main/java/com/pam/harvestcraft/worldgen/BushWorldGen.java
+++ b/src/main/java/com/pam/harvestcraft/worldgen/BushWorldGen.java
@@ -21,55 +21,46 @@ public class BushWorldGen implements IWorldGenerator {
     @Override
     public void generate(Random random, int chunkX, int chunkZ, World world, IChunkGenerator chunkGenerator, IChunkProvider chunkProvider) {
 
-        final int xChunk = chunkX * 16 + 8, zChunk = chunkZ * 16 + 8;
-        int xCh = chunkX * 16 + random.nextInt(16);
-        int yCh = random.nextInt(128);
-        int zCh = chunkZ * 16 + random.nextInt(16);
+        final int x = chunkX * 16 + 8;
+        final int z = chunkZ * 16 + 8;
 
-        final Biome biome = world.getBiomeForCoordsBody(new BlockPos(xChunk + 16, 0, zChunk + 16));
-        final BlockPos blockPos = new BlockPos(xCh, yCh + 64, zCh);
+        final Biome biome = world.getBiomeForCoordsBody(new BlockPos(x, 0, z));
         if (BiomeDictionary.hasType(biome, BiomeDictionary.Type.DEAD)) {
             return;
         }
 
-
         if (config.enablearidgardenGeneration && (BiomeDictionary.hasType(biome, BiomeDictionary.Type.SANDY)) || (BiomeDictionary.hasType(biome, BiomeDictionary.Type.MESA))) {
-            generateGarden(BlockRegistry.getGarden(BlockRegistry.aridGarden), world, blockPos);
+            generateGarden(BlockRegistry.getGarden(BlockRegistry.aridGarden), world, random, x, z);
         }
 
         if (config.enablefrostgardenGeneration && (BiomeDictionary.hasType(biome, BiomeDictionary.Type.SNOWY)) || (BiomeDictionary.hasType(biome, BiomeDictionary.Type.MOUNTAIN))) {
-            generateGarden(BlockRegistry.getGarden(BlockRegistry.frostGarden), world, blockPos);
+            generateGarden(BlockRegistry.getGarden(BlockRegistry.frostGarden), world, random, x, z);
         }
 
         if (config.enableshadedgardenGeneration && (BiomeDictionary.hasType(biome, BiomeDictionary.Type.FOREST)) || (BiomeDictionary.hasType(biome, BiomeDictionary.Type.SPOOKY))) {
-            generateGarden(BlockRegistry.getGarden(BlockRegistry.shadedGarden), world, blockPos);
+            generateGarden(BlockRegistry.getGarden(BlockRegistry.shadedGarden), world, random, x, z);
         }
 
         if (config.enablesoggygardenGeneration && (BiomeDictionary.hasType(biome, BiomeDictionary.Type.SWAMP)) || (BiomeDictionary.hasType(biome, BiomeDictionary.Type.RIVER))) {
-            generateGarden(BlockRegistry.getGarden(BlockRegistry.soggyGarden), world, blockPos);
+            generateGarden(BlockRegistry.getGarden(BlockRegistry.soggyGarden), world, random, x, z);
         }
 
         if (config.enabletropicalgardenGeneration && (BiomeDictionary.hasType(biome, BiomeDictionary.Type.JUNGLE)) || (BiomeDictionary.hasType(biome, BiomeDictionary.Type.OCEAN))) {
-            generateGarden(BlockRegistry.getGarden(BlockRegistry.tropicalGarden), world, blockPos);
+            generateGarden(BlockRegistry.getGarden(BlockRegistry.tropicalGarden), world, random, x, z);
         }
 
         if (config.enablewindygardenGeneration && (BiomeDictionary.hasType(biome, BiomeDictionary.Type.PLAINS)) || (BiomeDictionary.hasType(biome, BiomeDictionary.Type.SAVANNA))) {
-            generateGarden(BlockRegistry.getGarden(BlockRegistry.windyGarden), world, blockPos);
+            generateGarden(BlockRegistry.getGarden(BlockRegistry.windyGarden), world, random, x, z);
         }
     }
 
-    private void generateGarden(BlockBaseGarden gardenBlock, World world, BlockPos pos) {
+    private void generateGarden(BlockBaseGarden gardenBlock, World world, Random random, int x, int z) {
+        if (random.nextFloat() < HarvestCraft.config.gardenRarity / 8.0f) {
+            final int posX = x + world.rand.nextInt(16);
+            final int posZ = z + world.rand.nextInt(16);
+            final BlockPos newPos = WorldGenHelper.getGroundPos(world, posX, posZ);
 
-        final int tries = 32 * HarvestCraft.config.gardenRarity;
-
-        for (int tryNum = 0; tryNum < tries; tryNum++) {
-            int posX = (pos.getX() + world.rand.nextInt(8)) - world.rand.nextInt(8);
-            int posY = (pos.getY() + world.rand.nextInt(4)) - world.rand.nextInt(4);
-            int posZ = (pos.getZ() + world.rand.nextInt(8)) - world.rand.nextInt(8);
-
-            final BlockPos newPos = new BlockPos(posX, posY, posZ);
-
-            if (gardenBlock.canPlaceBlockAt(world, newPos)) {
+            if (newPos != null && gardenBlock.canPlaceBlockAt(world, newPos)) {
                 world.setBlockState(newPos, gardenBlock.getDefaultState(), 2);
             }
         }

--- a/src/main/java/com/pam/harvestcraft/worldgen/FruitTreeWorldGen.java
+++ b/src/main/java/com/pam/harvestcraft/worldgen/FruitTreeWorldGen.java
@@ -19,13 +19,14 @@ public class FruitTreeWorldGen implements IWorldGenerator {
 
     @Override
     public void generate(Random random, int chunkX, int chunkZ, World world, IChunkGenerator chunkGenerator, IChunkProvider chunkProvider) {
-        final int xChunk = chunkX * 16 + 8, zChunk = chunkZ * 16 + 8;
-        final int xCh = chunkX * 16 + random.nextInt(16);
-        final int yCh = random.nextInt(128) + 64;
-        final int zCh = chunkZ * 16 + random.nextInt(16);
+        if (random.nextFloat() > 0.12f) {
+            return;
+        }
 
-        final Biome biome = world.getBiomeForCoordsBody(new BlockPos(xChunk + 16, 0, zChunk + 16));
-        final BlockPos blockPos = new BlockPos(xCh, yCh, zCh);
+        final int x = chunkX * 16 + 8 + random.nextInt(16);
+        final int z = chunkZ * 16 + 8 + random.nextInt(16);
+
+        final Biome biome = world.getBiomeForCoordsBody(new BlockPos(x, 64, z));
 
         if (BiomeDictionary.hasType(biome, BiomeDictionary.Type.DEAD)) {
             return;
@@ -39,48 +40,48 @@ public class FruitTreeWorldGen implements IWorldGenerator {
                 switch (random.nextInt(9)) {
                     case 0:
                         if (config.appletreeGeneration) {
-                            generateFruitTree(world, blockPos, FruitRegistry.APPLE);
-                            break;
+                            generateFruitTree(world, random, FruitRegistry.APPLE, x, z);
+                            return;
                         }
                     case 1:
                         if (config.avocadotreeGeneration) {
-                            generateFruitTree(world, blockPos, FruitRegistry.AVOCADO);
-                            break;
+                            generateFruitTree(world, random, FruitRegistry.AVOCADO, x, z);
+                            return;
                         }
                     case 2:
                         if (config.cherrytreeGeneration) {
-                            generateFruitTree(world, blockPos, FruitRegistry.CHERRY);
-                            break;
+                            generateFruitTree(world, random, FruitRegistry.CHERRY, x, z);
+                            return;
                         }
                     case 3:
                         if (config.chestnuttreeGeneration) {
-                            generateFruitTree(world, blockPos, FruitRegistry.CHESTNUT);
-                            break;
+                            generateFruitTree(world, random, FruitRegistry.CHESTNUT, x, z);
+                            return;
                         }
                     case 4:
                         if (config.nutmegtreeGeneration) {
-                            generateFruitTree(world, blockPos, FruitRegistry.NUTMEG);
-                            break;
+                            generateFruitTree(world, random, FruitRegistry.NUTMEG, x, z);
+                            return;
                         }
                     case 5:
                         if (config.peartreeGeneration) {
-                            generateFruitTree(world, blockPos, FruitRegistry.PEAR);
-                            break;
+                            generateFruitTree(world, random, FruitRegistry.PEAR, x, z);
+                            return;
                         }
                     case 6:
                         if (config.plumtreeGeneration) {
-                            generateFruitTree(world, blockPos, FruitRegistry.PLUM);
-                            break;
+                            generateFruitTree(world, random, FruitRegistry.PLUM, x, z);
+                            return;
                         }
                     case 7:
                         if (config.walnuttreeGeneration) {
-                            generateFruitTree(world, blockPos, FruitRegistry.WALNUT);
-                            break;
+                            generateFruitTree(world, random, FruitRegistry.WALNUT, x, z);
+                            return;
                         }
                     case 8:
                         if (config.gooseberrytreeGeneration) {
-                            generateFruitTree(world, blockPos, FruitRegistry.GOOSEBERRY);
-                            break;
+                            generateFruitTree(world, random, FruitRegistry.GOOSEBERRY, x, z);
+                            return;
                         }
                 }
             }
@@ -91,132 +92,133 @@ public class FruitTreeWorldGen implements IWorldGenerator {
             switch (random.nextInt(25)) {
                 case 0:
                     if (config.bananatreeGeneration) {
-                        generateFruitTree(world, blockPos, FruitRegistry.BANANA);
-                        break;
+                        generateFruitTree(world, random, FruitRegistry.BANANA, x, z);
+                        return;
                     }
                 case 1:
                     if (config.cinnamontreeGeneration) {
-                        generateFruitTree(world, blockPos, FruitRegistry.CINNAMON);
-                        break;
+                        generateFruitTree(world, random, FruitRegistry.CINNAMON, x, z);
+                        return;
                     }
                 case 2:
                     if (config.coconuttreeGeneration) {
-                        generateFruitTree(world, blockPos, FruitRegistry.COCONUT);
-                        break;
+                        generateFruitTree(world, random, FruitRegistry.COCONUT, x, z);
+                        return;
                     }
                 case 3:
                     if (config.datetreeGeneration) {
-                        generateFruitTree(world, blockPos, FruitRegistry.DATE);
-                        break;
+                        generateFruitTree(world, random, FruitRegistry.DATE, x, z);
+                        return;
                     }
                 case 4:
                     if (config.dragonfruittreeGeneration) {
-                        generateFruitTree(world, blockPos, FruitRegistry.DRAGONFRUIT);
-                        break;
+                        generateFruitTree(world, random, FruitRegistry.DRAGONFRUIT, x, z);
+                        return;
                     }
                 case 5:
                     if (config.papayatreeGeneration) {
-                        generateFruitTree(world, blockPos, FruitRegistry.PAPAYA);
-                        break;
+                        generateFruitTree(world, random, FruitRegistry.PAPAYA, x, z);
+                        return;
                     }
                 case 6:
                     if (config.almondtreeGeneration) {
-                        generateFruitTree(world, blockPos, FruitRegistry.ALMOND);
-                        break;
+                        generateFruitTree(world, random, FruitRegistry.ALMOND, x, z);
+                        return;
                     }
                 case 7:
                     if (config.apricottreeGeneration) {
-                        generateFruitTree(world, blockPos, FruitRegistry.APRICOT);
-                        break;
+                        generateFruitTree(world, random, FruitRegistry.APRICOT, x, z);
+                        return;
                     }
                 case 8:
                     if (config.cashewtreeGeneration) {
-                        generateFruitTree(world, blockPos, FruitRegistry.CASHEW);
-                        break;
+                        generateFruitTree(world, random, FruitRegistry.CASHEW, x, z);
+                        return;
                     }
                 case 9:
                     if (config.duriantreeGeneration) {
-                        generateFruitTree(world, blockPos, FruitRegistry.DURIAN);
-                        break;
+                        generateFruitTree(world, random, FruitRegistry.DURIAN, x, z);
+                        return;
                     }
                 case 10:
                     if (config.figtreeGeneration) {
-                        generateFruitTree(world, blockPos, FruitRegistry.FIG);
-                        break;
+                        generateFruitTree(world, random, FruitRegistry.FIG, x, z);
+                        return;
                     }
                 case 11:
                     if (config.grapefruittreeGeneration) {
-                        generateFruitTree(world, blockPos, FruitRegistry.GRAPEFRUIT);
-                        break;
+                        generateFruitTree(world, random, FruitRegistry.GRAPEFRUIT, x, z);
+                        return;
                     }
                 case 12:
                     if (config.lemontreeGeneration) {
-                        generateFruitTree(world, blockPos, FruitRegistry.LEMON);
-                        break;
+                        generateFruitTree(world, random, FruitRegistry.LEMON, x, z);
+                        return;
                     }
                 case 13:
                     if (config.limetreeGeneration) {
-                        generateFruitTree(world, blockPos, FruitRegistry.LIME);
-                        break;
+                        generateFruitTree(world, random, FruitRegistry.LIME, x, z);
+                        return;
                     }
                 case 14:
                     if (config.mangotreeGeneration) {
-                        generateFruitTree(world, blockPos, FruitRegistry.MANGO);
-                        break;
+                        generateFruitTree(world, random, FruitRegistry.MANGO, x, z);
+                        return;
                     }
                 case 15:
                     if (config.orangetreeGeneration) {
-                        generateFruitTree(world, blockPos, FruitRegistry.ORANGE);
-                        break;
+                        generateFruitTree(world, random, FruitRegistry.ORANGE, x, z);
+                        return;
                     }
                 case 16:
                     if (config.paperbarktreeGeneration) {
-                        generateFruitTree(world, blockPos, FruitRegistry.PAPERBARK);
-                        break;
+                        generateFruitTree(world, random, FruitRegistry.PAPERBARK, x, z);
+                        return;
                     }
                 case 17:
                     if (config.peachtreeGeneration) {
-                        generateFruitTree(world, blockPos, FruitRegistry.PEACH);
-                        break;
+                        generateFruitTree(world, random, FruitRegistry.PEACH, x, z);
+                        return;
                     }
                 case 18:
                     if (config.pecantreeGeneration) {
-                        generateFruitTree(world, blockPos, FruitRegistry.PECAN);
-                        break;
+                        generateFruitTree(world, random, FruitRegistry.PECAN, x, z);
+                        return;
                     }
                 case 19:
                     if (config.peppercorntreeGeneration) {
-                        generateFruitTree(world, blockPos, FruitRegistry.PEPPERCORN);
-                        break;
+                        generateFruitTree(world, random, FruitRegistry.PEPPERCORN, x, z);
+                        return;
                     }
                 case 20:
                     if (config.persimmontreeGeneration) {
-                        generateFruitTree(world, blockPos, FruitRegistry.PERSIMMON);
-                        break;
+                        generateFruitTree(world, random, FruitRegistry.PERSIMMON, x, z);
+                        return;
                     }
                 case 21:
                     if (config.pistachiotreeGeneration) {
-                        generateFruitTree(world, blockPos, FruitRegistry.PISTACHIO);
-                        break;
+                        generateFruitTree(world, random, FruitRegistry.PISTACHIO, x, z);
+                        return;
                     }
                 case 22:
                     if (config.pomegranatetreeGeneration) {
-                        generateFruitTree(world, blockPos, FruitRegistry.POMEGRANATE);
-                        break;
+                        generateFruitTree(world, random, FruitRegistry.POMEGRANATE, x, z);
+                        return;
                     }
                 case 23:
                     if (config.starfruittreeGeneration) {
-                        generateFruitTree(world, blockPos, FruitRegistry.STARFRUIT);
-                        break;
+                        generateFruitTree(world, random, FruitRegistry.STARFRUIT, x, z);
+                        return;
                     }
                 case 24:
                     if (config.vanillabeantreeGeneration) {
-                        generateFruitTree(world, blockPos, FruitRegistry.VANILLABEAN);
-                        break;
+                        generateFruitTree(world, random, FruitRegistry.VANILLABEAN, x, z);
+                        return;
                     }
                 case 25:
                     if (config.olivetreeGeneration) {
-                        generateFruitTree(world, blockPos, FruitRegistry.OLIVE);
+                        generateFruitTree(world, random, FruitRegistry.OLIVE, x, z);
+                        return;
                     }
             }
         }
@@ -225,17 +227,18 @@ public class FruitTreeWorldGen implements IWorldGenerator {
                 || (BiomeDictionary.hasType(biome, BiomeDictionary.Type.MOUNTAIN))
                 || (BiomeDictionary.hasType(biome, BiomeDictionary.Type.CONIFEROUS))) {
             if (config.mapletreeGeneration) {
-                generateFruitTree(world, blockPos, FruitRegistry.MAPLE);
+                generateFruitTree(world, random, FruitRegistry.MAPLE, x, z);
+                return;
             }
         }
 
     }
 
-    private void generateFruitTree(World world, BlockPos pos, String fruitName) {
+    private void generateFruitTree(World world, Random random, String fruitName, int x, int z) {
         final BlockPamSapling sapling = FruitRegistry.getSapling(fruitName);
-        if (sapling == null) return;
-
-        sapling.worldGenTrees(world, pos);
+        if (sapling != null) {
+            sapling.worldGenTree(world, random, x, z);
+        }
     }
 }
 

--- a/src/main/java/com/pam/harvestcraft/worldgen/WorldGenHelper.java
+++ b/src/main/java/com/pam/harvestcraft/worldgen/WorldGenHelper.java
@@ -1,0 +1,46 @@
+package com.pam.harvestcraft.worldgen;
+
+import javax.annotation.Nullable;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+public class WorldGenHelper {
+	/**
+	 * Gets the position just above the top solid or liquid ground block in the world.
+	 * Returns null if there is no solid or liquid ground at the given x,y coordinates.
+	 */
+	@Nullable
+	public static BlockPos getGroundPos(World world, int x, int z) {
+		final BlockPos topPos = world.getHeight(new BlockPos(x, 0, z));
+		if (topPos.getY() == 0) {
+			return null;
+		}
+
+		final BlockPos.MutableBlockPos pos = new BlockPos.MutableBlockPos(topPos);
+
+		IBlockState blockState = world.getBlockState(pos);
+		while (isTreeBlock(blockState, world, pos) || canReplace(blockState, world, pos)) {
+			pos.move(EnumFacing.DOWN);
+			if (pos.getY() <= 0) {
+				return null;
+			}
+			blockState = world.getBlockState(pos);
+		}
+
+		return pos.up();
+	}
+
+	public static boolean isTreeBlock(IBlockState blockState, World world, BlockPos pos) {
+		Block block = blockState.getBlock();
+		return block.isLeaves(blockState, world, pos) || block.isWood(world, pos);
+	}
+
+	public static boolean canReplace(IBlockState blockState, World world, BlockPos pos) {
+		Block block = blockState.getBlock();
+		return block.isReplaceable(world, pos) && !blockState.getMaterial().isLiquid();
+	}
+}


### PR DESCRIPTION
Hello, I'm a fan of the mod and while playing on a new pack we found some performance issues with the server lagging during worldgen. Harvestcraft was one of *several* mods that interacted together to cause lots of chunks to keep loading even if the player was standing still.

This PR fixes a couple things to make worldgen safe and fast:
 * Stops any runaway chunk generation.
   * This is done by offsetting worldgen everywhere by +8 +8 like vanilla does, and by making sure things that might spread into new chunks check `world.isBlockLoaded(pos)` before getting or setting the block state there.
 * Improves placement of worldgen by finding the world's surface. 
   * I figured this out for Forestry hive generation, basically instead of generating randomly and checking if the location is valid, there are some functions you can use to find the surface of the world very efficiently. The checks are basically the same, but it has a much higher chance of being a good spot. This makes worldgen from Harvestcraft very fast and reliable, so it is easier to fine-tune with the configs. 
    * Because they find a valid spot every time, the spawn rates had to be lowered to match the previous rates. It should be pretty close, I am very careful to test that I didn't make anything too different.