### PR TITLE
Fix ConcurrentModificationException with Market and Shipping Bin network handling

### DIFF
--- a/src/main/java/com/pam/harvestcraft/tileentities/MessageMarketBrowse.java
+++ b/src/main/java/com/pam/harvestcraft/tileentities/MessageMarketBrowse.java
@@ -38,17 +38,21 @@ public class MessageMarketBrowse implements IMessage, IMessageHandler<MessageMar
 		buf.writeInt(this.z);
 	}
 
-	public IMessage onMessage(MessageMarketBrowse message, MessageContext ctx) {
-		EntityPlayerMP player = ctx.getServerHandler().playerEntity;
+	public IMessage onMessage(final MessageMarketBrowse message, MessageContext ctx) {
+		final EntityPlayerMP player = ctx.getServerHandler().playerEntity;
+		player.getServerWorld().addScheduledTask(new Runnable() {
+			@Override
+			public void run() {
+				TileEntity tile_entity = player.world.getTileEntity(new BlockPos(message.x, message.y, message.z));
+				if ((tile_entity instanceof TileEntityMarket)) {
+					TileEntityMarket tileEntityMarket = (TileEntityMarket) tile_entity;
+					tileEntityMarket.setBrowsingInfo(message.itemNum);
+				}
 
-		TileEntity tile_entity = player.world.getTileEntity(new BlockPos(message.x, message.y, message.z));
-		if((tile_entity instanceof TileEntityMarket)) {
-			TileEntityMarket tileEntityMarket = (TileEntityMarket) tile_entity;
-			tileEntityMarket.setBrowsingInfo(message.itemNum);
-		}
-
-		final IBlockState state = player.world.getBlockState(new BlockPos(message.x, message.y, message.z));
-		player.world.notifyBlockUpdate(new BlockPos(message.x, message.y, message.z), state, state, 3);
+				final IBlockState state = player.world.getBlockState(new BlockPos(message.x, message.y, message.z));
+				player.world.notifyBlockUpdate(new BlockPos(message.x, message.y, message.z), state, state, 3);
+			}
+		});
 		return null;
 	}
 

--- a/src/main/java/com/pam/harvestcraft/tileentities/MessageMarketBuy.java
+++ b/src/main/java/com/pam/harvestcraft/tileentities/MessageMarketBuy.java
@@ -46,28 +46,31 @@ public class MessageMarketBuy implements IMessage, IMessageHandler<MessageMarket
 	}
 
 	@Override
-	public IMessage onMessage(MessageMarketBuy message, MessageContext ctx) {
+	public IMessage onMessage(final MessageMarketBuy message, MessageContext ctx) {
 		final EntityPlayerMP player = ctx.getServerHandler().playerEntity;
+		player.getServerWorld().addScheduledTask(new Runnable() {
+			@Override
+			public void run() {
+				final TileEntity tile_entity = player.world.getTileEntity(new BlockPos(message.x, message.y, message.z));
+				if((tile_entity instanceof TileEntityMarket)) {
+					final TileEntityMarket tileEntityMarket = (TileEntityMarket) tile_entity;
+					final MarketData data = MarketItems.getData(message.itemNum);
+					final int price = data.getPrice();
 
-		final TileEntity tile_entity = player.world.getTileEntity(new BlockPos(message.x, message.y, message.z));
-		if((tile_entity instanceof TileEntityMarket)) {
-			final TileEntityMarket tileEntityMarket = (TileEntityMarket) tile_entity;
-			final MarketData data = MarketItems.getData(message.itemNum);
-			final int price = data.getPrice();
+					if (message.shouldClear) {
+						tileEntityMarket.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null).getStackInSlot(0)
+								.setCount(0);
+					} else {
+						tileEntityMarket.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null).getStackInSlot(0)
+								.shrink(price);
+					}
 
-			if(message.shouldClear) {
-				tileEntityMarket.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null).getStackInSlot(0)
-						.setCount(0);
+					final EntityItem var14 =
+							new EntityItem(player.world, player.posX, player.posY + 1.0D, player.posZ, data.getItem().copy());
+					player.world.spawnEntity(var14);
+				}
 			}
-			else {
-				tileEntityMarket.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null).getStackInSlot(0)
-						.shrink(price);
-			}
-
-			final EntityItem var14 =
-					new EntityItem(player.world, player.posX, player.posY + 1.0D, player.posZ, data.getItem().copy());
-			player.world.spawnEntity(var14);
-		}
+		});
 		return null;
 	}
 }

--- a/src/main/java/com/pam/harvestcraft/tileentities/MessageShippingBinBrowse.java
+++ b/src/main/java/com/pam/harvestcraft/tileentities/MessageShippingBinBrowse.java
@@ -38,17 +38,21 @@ public class MessageShippingBinBrowse implements IMessage, IMessageHandler<Messa
 		buf.writeInt(this.z);
 	}
 
-	public IMessage onMessage(MessageShippingBinBrowse message, MessageContext ctx) {
-		EntityPlayerMP player = ctx.getServerHandler().playerEntity;
+	public IMessage onMessage(final MessageShippingBinBrowse message, MessageContext ctx) {
+		final EntityPlayerMP player = ctx.getServerHandler().playerEntity;
+		player.getServerWorld().addScheduledTask(new Runnable() {
+			@Override
+			public void run() {
+				TileEntity tile_entity = player.world.getTileEntity(new BlockPos(message.x, message.y, message.z));
+				if((tile_entity instanceof TileEntityShippingBin)) {
+					TileEntityShippingBin tileEntityShippingBin = (TileEntityShippingBin) tile_entity;
+					tileEntityShippingBin.setBrowsingInfo(message.itemNum);
+				}
 
-		TileEntity tile_entity = player.world.getTileEntity(new BlockPos(message.x, message.y, message.z));
-		if((tile_entity instanceof TileEntityShippingBin)) {
-			TileEntityShippingBin tileEntityShippingBin = (TileEntityShippingBin) tile_entity;
-			tileEntityShippingBin.setBrowsingInfo(message.itemNum);
-		}
-
-		final IBlockState state = player.world.getBlockState(new BlockPos(message.x, message.y, message.z));
-		player.world.notifyBlockUpdate(new BlockPos(message.x, message.y, message.z), state, state, 3);
+				final IBlockState state = player.world.getBlockState(new BlockPos(message.x, message.y, message.z));
+				player.world.notifyBlockUpdate(new BlockPos(message.x, message.y, message.z), state, state, 3);
+			}
+		});
 		return null;
 	}
 

--- a/src/main/java/com/pam/harvestcraft/tileentities/MessageShippingBinBuy.java
+++ b/src/main/java/com/pam/harvestcraft/tileentities/MessageShippingBinBuy.java
@@ -46,28 +46,32 @@ public class MessageShippingBinBuy implements IMessage, IMessageHandler<MessageS
 	}
 
 	@Override
-	public IMessage onMessage(MessageShippingBinBuy message, MessageContext ctx) {
+	public IMessage onMessage(final MessageShippingBinBuy message, MessageContext ctx) {
 		final EntityPlayerMP player = ctx.getServerHandler().playerEntity;
+		player.getServerWorld().addScheduledTask(new Runnable() {
+			@Override
+			public void run() {
+				final TileEntity tile_entity = player.world.getTileEntity(new BlockPos(message.x, message.y, message.z));
+				if((tile_entity instanceof TileEntityShippingBin)) {
+					final TileEntityShippingBin tileEntityShippingBin = (TileEntityShippingBin) tile_entity;
+					final ShippingBinData data = ShippingBinItems.getData(message.itemNum);
+					final int price = data.getPrice();
 
-		final TileEntity tile_entity = player.world.getTileEntity(new BlockPos(message.x, message.y, message.z));
-		if((tile_entity instanceof TileEntityShippingBin)) {
-			final TileEntityShippingBin tileEntityShippingBin = (TileEntityShippingBin) tile_entity;
-			final ShippingBinData data = ShippingBinItems.getData(message.itemNum);
-			final int price = data.getPrice();
+					if(message.shouldClear) {
+						tileEntityShippingBin.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null)
+								.getStackInSlot(0).setCount(0);
+					}
+					else {
+						tileEntityShippingBin.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null)
+								.getStackInSlot(0).shrink(price);
+					}
 
-			if(message.shouldClear) {
-				tileEntityShippingBin.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null)
-						.getStackInSlot(0).setCount(0);
+					final EntityItem var14 =
+							new EntityItem(player.world, player.posX, player.posY + 1.0D, player.posZ, data.getItem().copy());
+					player.world.spawnEntity(var14);
+				}
 			}
-			else {
-				tileEntityShippingBin.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null)
-						.getStackInSlot(0).shrink(price);
-			}
-
-			final EntityItem var14 =
-					new EntityItem(player.world, player.posX, player.posY + 1.0D, player.posZ, data.getItem().copy());
-			player.world.spawnEntity(var14);
-		}
+		});
 		return null;
 	}
 }

--- a/src/main/java/com/pam/harvestcraft/tileentities/MessageShippingBinClosed.java
+++ b/src/main/java/com/pam/harvestcraft/tileentities/MessageShippingBinClosed.java
@@ -35,24 +35,28 @@ public class MessageShippingBinClosed implements IMessage, IMessageHandler<Messa
 		buf.writeInt(this.z);
 	}
 
-	public IMessage onMessage(MessageShippingBinClosed message, MessageContext ctx) {
-		EntityPlayerMP player = ctx.getServerHandler().playerEntity;
+	public IMessage onMessage(final MessageShippingBinClosed message, MessageContext ctx) {
+		final EntityPlayerMP player = ctx.getServerHandler().playerEntity;
+		player.getServerWorld().addScheduledTask(new Runnable() {
+			@Override
+			public void run() {
+				TileEntity tile_entity = player.world.getTileEntity(new BlockPos(message.x, message.y, message.z));
+				if((tile_entity instanceof TileEntityShippingBin)) {
+					TileEntityShippingBin tileEntityShippingBin = (TileEntityShippingBin) tile_entity;
 
-		TileEntity tile_entity = player.world.getTileEntity(new BlockPos(message.x, message.y, message.z));
-		if((tile_entity instanceof TileEntityShippingBin)) {
-			TileEntityShippingBin tileEntityShippingBin = (TileEntityShippingBin) tile_entity;
+					if(!tileEntityShippingBin.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null)
+							.getStackInSlot(0).isEmpty()) {
+						player.entityDropItem(tileEntityShippingBin
+								.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null).getStackInSlot(0), 1.0F);
+						tileEntityShippingBin.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null)
+								.getStackInSlot(0).setCount(0);
+					}
+				}
 
-			if(!tileEntityShippingBin.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null)
-					.getStackInSlot(0).isEmpty()) {
-				player.entityDropItem(tileEntityShippingBin
-						.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null).getStackInSlot(0), 1.0F);
-				tileEntityShippingBin.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null)
-						.getStackInSlot(0).setCount(0);
+				final IBlockState state = player.world.getBlockState(new BlockPos(message.x, message.y, message.z));
+				player.world.notifyBlockUpdate(new BlockPos(message.x, message.y, message.z), state, state, 3);
 			}
-		}
-
-		final IBlockState state = player.world.getBlockState(new BlockPos(message.x, message.y, message.z));
-		player.world.notifyBlockUpdate(new BlockPos(message.x, message.y, message.z), state, state, 3);
+		});
 		return null;
 	}
 }


### PR DESCRIPTION
Hello,

This fixes a `ConcurrentModificationException` which was very hard to track down, it happens randomly with a low chance whenever a mod accesses the world from the network thread.

The original Market issue is here: https://github.com/Vaygrim/CoopLife/issues/25
The original Shipping Bin issue is here: https://github.com/MatrexsVigil/harvestcraft/issues/261
~~This might fix #259 too but I wasn't able to reproduce the issue.~~

`IMessageHandler#onMessage` is called on a network thread, so you have to switch to the main thread if you want to interact with the world.

This PR fixes the Market's and Shipping Bin's network packets so that their world interaction logic gets run on the main thread. The logic is left the same.