### PR TITLE
Add missing Forge event hooks to BlockCrops growth updates

### DIFF
--- a/src/main/java/com/pam/harvestcraft/blocks/growables/BlockPamCrop.java
+++ b/src/main/java/com/pam/harvestcraft/blocks/growables/BlockPamCrop.java
@@ -136,8 +136,9 @@ public class BlockPamCrop extends BlockCrops implements IGrowable, IPlantable, P
             if (currentGrowthLevel < getMatureAge()) {
                 float f = getGrowthChance(this, worldIn, pos);
 
-                if (rand.nextInt((int) (50.0F / f) + 1) == 0) {
+                if(net.minecraftforge.common.ForgeHooks.onCropsGrowPre(worldIn, pos, state, rand.nextInt((int)(50.0F / f) + 1) == 0)) {
                     worldIn.setBlockState(pos, this.getStateFromMeta(currentGrowthLevel + 1), 2);
+                    net.minecraftforge.common.ForgeHooks.onCropsGrowPost(worldIn, pos, state, worldIn.getBlockState(pos));
                 }
             }
         }


### PR DESCRIPTION
BlockCrops overrides the updateTick() method in removing the Forge events for both Pre and Post crop growth. This commit should add the missing event hooks allowing other mods to work better with Harvestcraft crops.

I retained the doubled growth rate hardcoded into the method.

I submitted this before, but it wasn't a clean fix. Thanks for considering this.