### PR TITLE
Fix all tiles not properly overriding getUpdateTag.

### DIFF
--- a/src/main/java/com/pam/harvestcraft/proxy/CommonProxy.java
+++ b/src/main/java/com/pam/harvestcraft/proxy/CommonProxy.java
@@ -11,7 +11,6 @@ import com.pam.harvestcraft.config.ConfigHandler;
 import com.pam.harvestcraft.item.GeneralOreRegistry;
 import com.pam.harvestcraft.item.ItemRegistry;
 import com.pam.harvestcraft.item.RecipeRegistry;
-import com.pam.harvestcraft.item.RecipeRemoval;
 import com.pam.harvestcraft.item.SeedDropRegistry;
 import com.pam.harvestcraft.loottables.LootTableLoadEventHandler;
 import com.pam.harvestcraft.tileentities.MarketItems;

--- a/src/main/java/com/pam/harvestcraft/tileentities/TileEntityApiary.java
+++ b/src/main/java/com/pam/harvestcraft/tileentities/TileEntityApiary.java
@@ -61,6 +61,11 @@ public class TileEntityApiary extends TileEntity implements ITickable {
 	}
 
 	@Override
+	public NBTTagCompound getUpdateTag() {
+		return writeToNBT(new NBTTagCompound());
+	}
+
+	@Override
 	public void update() {
 		boolean isRunning = runTime > 0;
 		boolean needsUpdate = false;

--- a/src/main/java/com/pam/harvestcraft/tileentities/TileEntityGroundTrap.java
+++ b/src/main/java/com/pam/harvestcraft/tileentities/TileEntityGroundTrap.java
@@ -65,6 +65,11 @@ public class TileEntityGroundTrap extends TileEntity implements ITickable {
 		return compound;
 	}
 
+	@Override
+	public NBTTagCompound getUpdateTag() {
+		return writeToNBT(new NBTTagCompound());
+	}
+
 	public int countFlowers() {
 		byte radius = 2;
 		int count = 0;

--- a/src/main/java/com/pam/harvestcraft/tileentities/TileEntityMarket.java
+++ b/src/main/java/com/pam/harvestcraft/tileentities/TileEntityMarket.java
@@ -52,6 +52,11 @@ public class TileEntityMarket extends TileEntity {
 		return tagCompound;
 	}
 
+	@Override
+	public NBTTagCompound getUpdateTag() {
+		return writeToNBT(new NBTTagCompound());
+	}
+
 	public int getBrowsingInfo() {
 		return stockNum;
 	}

--- a/src/main/java/com/pam/harvestcraft/tileentities/TileEntityPresser.java
+++ b/src/main/java/com/pam/harvestcraft/tileentities/TileEntityPresser.java
@@ -52,6 +52,11 @@ public class TileEntityPresser extends TileEntity implements ITickable {
 		return super.writeToNBT(compound);
 	}
 
+	@Override
+	public NBTTagCompound getUpdateTag() {
+		return writeToNBT(new NBTTagCompound());
+	}
+
 	@SideOnly(value = Side.CLIENT)
 	public int getCookProgressScaled(int scale) {
 		return cookTime * scale / 125;

--- a/src/main/java/com/pam/harvestcraft/tileentities/TileEntityShippingBin.java
+++ b/src/main/java/com/pam/harvestcraft/tileentities/TileEntityShippingBin.java
@@ -51,6 +51,11 @@ public class TileEntityShippingBin extends TileEntity {
 		return tagCompound;
 	}
 
+	@Override
+	public NBTTagCompound getUpdateTag() {
+		return writeToNBT(new NBTTagCompound());
+	}
+
 	public int getBrowsingInfo() {
 		return stockNum;
 	}

--- a/src/main/java/com/pam/harvestcraft/tileentities/TileEntityWaterTrap.java
+++ b/src/main/java/com/pam/harvestcraft/tileentities/TileEntityWaterTrap.java
@@ -63,6 +63,11 @@ public class TileEntityWaterTrap extends TileEntity implements ITickable {
 		return super.writeToNBT(compound);
 	}
 
+	@Override
+	public NBTTagCompound getUpdateTag() {
+		return writeToNBT(new NBTTagCompound());
+	}
+
 	public int countFlowers() {
 		byte radius = 2;
 		int count = 0;


### PR DESCRIPTION
This resolves basically all issues with harvest craft blocks causing funky issues with other mods on client login. See https://github.com/MatrexsVigil/harvestcraft/issues/29 for a detailed explanation of the problem. After further inspection from that issue it was apparent that all tiles in harvest craft had this issue. Overriding getUpdateTag and simply calling writeToNBT fixes the issue outright. Resolves #39 and probably almost all the issues on the tracker but don't quote me on that.