### PR TITLE
Allow HungerOverhaul to access the AGE property on BlockPamCrop witho…

### DIFF
--- a/src/main/java/com/pam/harvestcraft/blocks/growables/BlockPamCrop.java
+++ b/src/main/java/com/pam/harvestcraft/blocks/growables/BlockPamCrop.java
@@ -29,7 +29,7 @@ public class BlockPamCrop extends BlockCrops implements IGrowable, IPlantable, P
 
 	private static final int MATURE_AGE = 3;
 
-	private static final PropertyInteger AGE = PropertyInteger.create("age", 0, MATURE_AGE);
+	public static final PropertyInteger AGE = PropertyInteger.create("age", 0, MATURE_AGE);
 
 	private static final AxisAlignedBB[] CROPS_AABB =
 			new AxisAlignedBB[] {new AxisAlignedBB(0.0D, 0.0D, 0.0D, 1.0D, 0.125D, 1.0D),


### PR DESCRIPTION
…ut the use of a reflection handler.

This removes the use of HungerOverhaul's ReflectionModule (https://github.com/progwml6/HungerOverhaul/blob/1.12/src/main/java/iguanaman/hungeroverhaul/module/reflection/ReflectionModule.java), The BlockPamFruit and BlockPamFruitLog's AGE properties are public, but BlockPamCrop's isn't.