### PR TITLE
FruitTree Configuration rewritten

### DIFF
--- a/src/main/java/com/pam/harvestcraft/HarvestCraft.java
+++ b/src/main/java/com/pam/harvestcraft/HarvestCraft.java
@@ -1,6 +1,7 @@
 package com.pam.harvestcraft;
 
 import com.pam.harvestcraft.config.ConfigHandler;
+import com.pam.harvestcraft.config.FruitTreeConfigManager;
 import com.pam.harvestcraft.gui.GuiHandler;
 import com.pam.harvestcraft.item.ItemRegistry;
 import com.pam.harvestcraft.proxy.CommonProxy;
@@ -20,6 +21,8 @@ import net.minecraftforge.fml.common.network.simpleimpl.SimpleNetworkWrapper;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
+import java.io.File;
+
 @Mod(modid = Reference.MODID, name = Reference.NAME, version = Reference.VERSION)
 public class HarvestCraft {
 
@@ -37,10 +40,15 @@ public class HarvestCraft {
 	};
 
 	public static ConfigHandler config;
+	public static FruitTreeConfigManager fruitTreeConfigManager;
 
 	@EventHandler
 	public void preInit(FMLPreInitializationEvent event) {
 		config = new ConfigHandler(new Configuration(event.getSuggestedConfigurationFile()));
+
+        fruitTreeConfigManager = new FruitTreeConfigManager(
+        		new Configuration(
+        				new File(event.getModConfigurationDirectory(), Reference.MODID + "_fruittree" + ".cfg")));
 		proxy.preInit(event);
 		NetworkRegistry.INSTANCE.registerGuiHandler(instance, new GuiHandler());
 		//final SimpleNetworkWrapper NETWORKINSTANCE = NetworkRegistry.INSTANCE.newSimpleChannel(Reference.MODID);
@@ -48,6 +56,7 @@ public class HarvestCraft {
 
 	@EventHandler
 	public void init(FMLInitializationEvent event) {
+		fruitTreeConfigManager.Configure();
 		proxy.init(event);
 	}
 

--- a/src/main/java/com/pam/harvestcraft/blocks/growables/BlockPamFruit.java
+++ b/src/main/java/com/pam/harvestcraft/blocks/growables/BlockPamFruit.java
@@ -6,6 +6,7 @@ import java.util.Random;
 
 import javax.annotation.Nullable;
 
+import com.pam.harvestcraft.HarvestCraft;
 import com.pam.harvestcraft.config.ConfigHandler;
 
 import net.minecraft.block.Block;
@@ -209,7 +210,7 @@ public class BlockPamFruit extends Block implements IGrowable, PamCropGrowable, 
 	public void updateTick(World worldIn, BlockPos pos, IBlockState state, Random rand) {
 		int i = state.getValue(AGE);
 
-		if(i < MATURE_AGE && rand.nextInt(ConfigHandler.fruitGrowthSpeed) == 0) {
+		if(i < MATURE_AGE && rand.nextInt(HarvestCraft.fruitTreeConfigManager.getFruitGrowthSpeed()) == 0) {
 			state = state.withProperty(AGE, i + 1);
 			worldIn.setBlockState(pos, state, 2);
 		}

--- a/src/main/java/com/pam/harvestcraft/blocks/growables/BlockPamFruitLog.java
+++ b/src/main/java/com/pam/harvestcraft/blocks/growables/BlockPamFruitLog.java
@@ -121,7 +121,7 @@ public class BlockPamFruitLog extends Block implements IGrowable, PamCropGrowabl
 	public void updateTick(World worldIn, BlockPos pos, IBlockState state, Random rand) {
 		int i = state.getValue(AGE);
 
-		if(i < MATURE_AGE && rand.nextInt(ConfigHandler.fruitGrowthSpeed) == 0) {
+		if(i < MATURE_AGE && rand.nextInt(HarvestCraft.fruitTreeConfigManager.getFruitGrowthSpeed()) == 0) {
 			state = state.withProperty(AGE, i + 1);
 			worldIn.setBlockState(pos, state, 2);
 		}

--- a/src/main/java/com/pam/harvestcraft/blocks/growables/BlockPamSapling.java
+++ b/src/main/java/com/pam/harvestcraft/blocks/growables/BlockPamSapling.java
@@ -39,7 +39,6 @@ public class BlockPamSapling extends BlockBush implements IGrowable {
 
     // Caching information for sapling.
     private final BlockPlanks.EnumType planks;
-    private final int rarity;
     private final IBlockState logState;
     private final IBlockState leavesState;
 
@@ -55,17 +54,14 @@ public class BlockPamSapling extends BlockBush implements IGrowable {
         switch (saplingType) {
             case WARM:
                 planks = BlockPlanks.EnumType.JUNGLE;
-                rarity = HarvestCraft.config.tropicalfruittreeRarity;
                 break;
 
             case COLD:
                 planks = BlockPlanks.EnumType.SPRUCE;
-                rarity = HarvestCraft.config.coniferousfruittreeRarity;
                 break;
             case TEMPERATE:
             default:
                 planks = BlockPlanks.EnumType.OAK;
-                rarity = HarvestCraft.config.temperatefruittreeRarity;
         }
 
         logState = Blocks.LOG.getDefaultState().withProperty(BlockOldLog.VARIANT, planks);
@@ -150,7 +146,6 @@ public class BlockPamSapling extends BlockBush implements IGrowable {
     }
 
     public void worldGenTree(World world, Random random, int x, int z) {
-        if (random.nextFloat() > rarity / 64.0f) return;
 
         final BlockPos pos = WorldGenHelper.getGroundPos(world, x, z);
         if (pos == null) return;

--- a/src/main/java/com/pam/harvestcraft/config/ConfigHandler.java
+++ b/src/main/java/com/pam/harvestcraft/config/ConfigHandler.java
@@ -7,7 +7,6 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import com.pam.harvestcraft.HarvestCraft;
 import com.pam.harvestcraft.blocks.CropRegistry;
 import com.pam.harvestcraft.blocks.blocks.BlockBaseGarden;
 
@@ -23,7 +22,6 @@ public class ConfigHandler {
     private static final String CATEGORY_GENERAL = "general";
     private static final String CATEGORY_CROPS = "crops";
     private static final String CATEGORY_GARDENS = "gardens";
-    private static final String CATEGORY_FRUIT_TREES = "fruit trees";
     private static final String CATEGORY_SALT = "salt";
     private static final String CATEGORY_BEE = "beekeeping";
     private static final String CATEGORY_MARKET_SALES = "market sales";
@@ -45,7 +43,6 @@ public class ConfigHandler {
     private static final double defaultSaturationMeal = 1.2D;
     private static final double defaultSaturationMeatyMeal = 1.600000023841858D;
     private static final double defaultCropGrowthSpeed = 0.0D;
-    private static final double defaultFruitGrowthSpeed = 0.0D;
 
     /**
      * Config
@@ -58,7 +55,6 @@ public class ConfigHandler {
     public static boolean cropsdropSeeds;
     
     public static float cropGrowthSpeed;
-    public static int fruitGrowthSpeed;
 
     public float snacksaturation;
     public float mealsaturation;
@@ -108,46 +104,6 @@ public class ConfigHandler {
     public boolean enablewindygardenGeneration;
     public boolean enableshadedgardenGeneration;
     public boolean enablesoggygardenGeneration;
-    public int temperatefruittreeRarity;
-    public int tropicalfruittreeRarity;
-    public int coniferousfruittreeRarity;
-    public boolean appletreeGeneration;
-    public boolean almondtreeGeneration;
-    public boolean apricottreeGeneration;
-    public boolean avocadotreeGeneration;
-    public boolean bananatreeGeneration;
-    public boolean cashewtreeGeneration;
-    public boolean cherrytreeGeneration;
-    public boolean chestnuttreeGeneration;
-    public boolean cinnamontreeGeneration;
-    public boolean coconuttreeGeneration;
-    public boolean datetreeGeneration;
-    public boolean dragonfruittreeGeneration;
-    public boolean duriantreeGeneration;
-    public boolean figtreeGeneration;
-    public boolean grapefruittreeGeneration;
-    public boolean lemontreeGeneration;
-    public boolean limetreeGeneration;
-    public boolean mapletreeGeneration;
-    public boolean mangotreeGeneration;
-    public boolean nutmegtreeGeneration;
-    public boolean olivetreeGeneration;
-    public boolean orangetreeGeneration;
-    public boolean papayatreeGeneration;
-    public boolean paperbarktreeGeneration;
-    public boolean peachtreeGeneration;
-    public boolean peartreeGeneration;
-    public boolean pecantreeGeneration;
-    public boolean peppercorntreeGeneration;
-    public boolean persimmontreeGeneration;
-    public boolean pistachiotreeGeneration;
-    public boolean plumtreeGeneration;
-    public boolean pomegranatetreeGeneration;
-    public boolean starfruittreeGeneration;
-    public boolean vanillabeantreeGeneration;
-    public boolean walnuttreeGeneration;
-    public boolean gooseberrytreeGeneration;
-    public boolean spiderwebtreeGeneration;
     public boolean enablecropspecialplanting;
 
     // Market configuration
@@ -241,7 +197,6 @@ public class ConfigHandler {
         initGeneralSettings();
         initCropSettings();
         initSeedDropSettings();
-        initFoodTreesSettings();
         initGardenSettings();
         initMarketSettings();
         initBeesSettings();
@@ -278,52 +233,8 @@ public class ConfigHandler {
         meatymealsaturation = (float) config.get(CATEGORY_CROPS, "meatymealsaturation", defaultSaturationMeatyMeal).getDouble();
         enablecropspecialplanting = config.get(CATEGORY_CROPS, "enablecropspecialplanting", true).getBoolean();
         cropsdropSeeds = config.get(CATEGORY_CROPS, "cropsdropSeeds", false).getBoolean();
-		cropGrowthSpeed = (float) config.get(CATEGORY_CROPS, "cropGrowthSpeed", defaultCropGrowthSpeed, "Default: 0.0, This number is added/subtracted from normal fertile crop growth (3.0) and adjacent fertile crop growth (4.0).").getDouble();
-		enablegigapickleCrop = config.get(CATEGORY_CROPS, "enablegigapickleCrop", true, "Disable to keep giga pickle crop seeds from appearing in dungeon chests").getBoolean();
-    }
-
-    private void initFoodTreesSettings() {
-    	fruitGrowthSpeed = config.get(CATEGORY_FRUIT_TREES, "fruitGrowthSpeed", 25, "Default: 25, Lower is faster").getInt();
-        temperatefruittreeRarity = config.get(CATEGORY_FRUIT_TREES, "temperatefruittreeRarity", 48).getInt();
-        tropicalfruittreeRarity = config.get(CATEGORY_FRUIT_TREES, "tropicalfruittreeRarity", 64).getInt();
-        coniferousfruittreeRarity = config.get(CATEGORY_FRUIT_TREES, "coniferousfruittreeRarity", 48).getInt();
-        appletreeGeneration = config.get(CATEGORY_FRUIT_TREES, "appletreeGeneration", true).getBoolean();
-        almondtreeGeneration = config.get(CATEGORY_FRUIT_TREES, "almondtreeGeneration", true).getBoolean();
-        apricottreeGeneration = config.get(CATEGORY_FRUIT_TREES, "apricottreeGeneration", true).getBoolean();
-        avocadotreeGeneration = config.get(CATEGORY_FRUIT_TREES, "avocadotreeGeneration", true).getBoolean();
-        bananatreeGeneration = config.get(CATEGORY_FRUIT_TREES, "bananatreeGeneration", true).getBoolean();
-        cashewtreeGeneration = config.get(CATEGORY_FRUIT_TREES, "cashewtreeGeneration", true).getBoolean();
-        cherrytreeGeneration = config.get(CATEGORY_FRUIT_TREES, "cherrytreeGeneration", true).getBoolean();
-        chestnuttreeGeneration = config.get(CATEGORY_FRUIT_TREES, "chestnuttreeGeneration", true).getBoolean();
-        cinnamontreeGeneration = config.get(CATEGORY_FRUIT_TREES, "cinnamontreeGeneration", true).getBoolean();
-        coconuttreeGeneration = config.get(CATEGORY_FRUIT_TREES, "coconuttreeGeneration", true).getBoolean();
-        datetreeGeneration = config.get(CATEGORY_FRUIT_TREES, "datetreeGeneration", true).getBoolean();
-        dragonfruittreeGeneration = config.get(CATEGORY_FRUIT_TREES, "dragonfruittreeGeneration", true).getBoolean();
-        duriantreeGeneration = config.get(CATEGORY_FRUIT_TREES, "duriantreeGeneration", true).getBoolean();
-        figtreeGeneration = config.get(CATEGORY_FRUIT_TREES, "figtreeGeneration", true).getBoolean();
-        grapefruittreeGeneration = config.get(CATEGORY_FRUIT_TREES, "grapefruittreeGeneration", true).getBoolean();
-        lemontreeGeneration = config.get(CATEGORY_FRUIT_TREES, "lemontreeGeneration", true).getBoolean();
-        limetreeGeneration = config.get(CATEGORY_FRUIT_TREES, "limetreeGeneration", true).getBoolean();
-        mapletreeGeneration = config.get(CATEGORY_FRUIT_TREES, "mapletreeGeneration", true).getBoolean();
-        mangotreeGeneration = config.get(CATEGORY_FRUIT_TREES, "mangotreeGeneration", true).getBoolean();
-        nutmegtreeGeneration = config.get(CATEGORY_FRUIT_TREES, "nutmegtreeGeneration", true).getBoolean();
-        olivetreeGeneration = config.get(CATEGORY_FRUIT_TREES, "olivetreeGeneration", true).getBoolean();
-        orangetreeGeneration = config.get(CATEGORY_FRUIT_TREES, "orangetreeGeneration", true).getBoolean();
-        papayatreeGeneration = config.get(CATEGORY_FRUIT_TREES, "papayatreeGeneration", true).getBoolean();
-        paperbarktreeGeneration = config.get(CATEGORY_FRUIT_TREES, "paperbarktreeGeneration", true).getBoolean();
-        peachtreeGeneration = config.get(CATEGORY_FRUIT_TREES, "peachtreeGeneration", true).getBoolean();
-        peartreeGeneration = config.get(CATEGORY_FRUIT_TREES, "peartreeGeneration", true).getBoolean();
-        pecantreeGeneration = config.get(CATEGORY_FRUIT_TREES, "pecantreeGeneration", true).getBoolean();
-        peppercorntreeGeneration = config.get(CATEGORY_FRUIT_TREES, "peppercorntreeGeneration", true).getBoolean();
-        persimmontreeGeneration = config.get(CATEGORY_FRUIT_TREES, "persimmontreeGeneration", true).getBoolean();
-        pistachiotreeGeneration = config.get(CATEGORY_FRUIT_TREES, "pistachiotreeGeneration", true).getBoolean();
-        plumtreeGeneration = config.get(CATEGORY_FRUIT_TREES, "plumtreeGeneration", true).getBoolean();
-        pomegranatetreeGeneration = config.get(CATEGORY_FRUIT_TREES, "pomegranatetreeGeneration", true).getBoolean();
-        starfruittreeGeneration = config.get(CATEGORY_FRUIT_TREES, "starfruittreeGeneration", true).getBoolean();
-        vanillabeantreeGeneration = config.get(CATEGORY_FRUIT_TREES, "vanillabeantreeGeneration", true).getBoolean();
-        walnuttreeGeneration = config.get(CATEGORY_FRUIT_TREES, "walnuttreeGeneration", true).getBoolean();
-        gooseberrytreeGeneration = config.get(CATEGORY_FRUIT_TREES, "gooseberrytreeGeneration", true).getBoolean();
-        spiderwebtreeGeneration = config.get(CATEGORY_FRUIT_TREES, "spiderwebtreeGeneration", true).getBoolean();
+        cropGrowthSpeed = (float) config.get(CATEGORY_CROPS, "cropGrowthSpeed", defaultCropGrowthSpeed, "Default: 0.0, This number is added/subtracted from normal fertile crop growth (3.0) and adjacent fertile crop growth (4.0).").getDouble();
+        enablegigapickleCrop = config.get(CATEGORY_CROPS, "enablegigapickleCrop", true, "Disable to keep giga pickle crop seeds from appearing in dungeon chests").getBoolean();
     }
 
     private void initGardenSettings() {

--- a/src/main/java/com/pam/harvestcraft/config/FruitTreeConfigManager.java
+++ b/src/main/java/com/pam/harvestcraft/config/FruitTreeConfigManager.java
@@ -1,0 +1,181 @@
+package com.pam.harvestcraft.config;
+
+import com.pam.harvestcraft.blocks.FruitRegistry;
+import com.pam.harvestcraft.blocks.growables.BlockPamSapling;
+import net.minecraft.world.biome.Biome;
+import net.minecraftforge.common.BiomeDictionary;
+import net.minecraftforge.common.config.Configuration;
+import net.minecraftforge.fml.common.FMLLog;
+import net.minecraftforge.fml.common.registry.ForgeRegistries;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+public class FruitTreeConfigManager {
+    private final String WHITELIST = "whitelist";
+    private static final String CATEGORY_FRUIT_TREES_COMMON = "_common_fruit_trees";
+
+    private static String[] defaultWarm = new String[]{
+            "minecraft:savanna",
+            "minecraft:jungle",
+            "minecraft:jungle_hills",
+            "minecraft:jungle_edge",
+            "minecraft:mutated_jungle",
+            "minecraft:mutated_jungle_edge",
+            "biomesoplenty:chaparral",
+            "biomesoplenty:sacred_springs",
+            "biomesoplenty:bamboo_forest",
+            "biomesoplenty:eucalyptus_forest",
+            "biomesoplenty:prairie",
+            "biomesoplenty:rainforest",
+            "biomesoplenty:tropical_rainforest",
+            "biomesoplenty:oasis",
+            "biomesoplenty:tropical_island",
+    };
+
+    private static String[] defaultTemperate = new String[]{
+            // TEMPERATURE CATEGORY MEDIUM: 0.6 ... 0.85
+            "minecraft:forest",
+            "minecraft:river",
+            "minecraft:forest_hills",
+            "minecraft:birch_forest",
+            "minecraft:birch_forest_hills",
+            "minecraft:roofed_forest",
+            "minecraft:mutated_forest",
+            "minecraft:mutated_birch_forest",
+            "minecraft:mutated_birch_forest_hills",
+            "minecraft:mutated_roofed_forest",
+            "biomesoplenty:boreal_forest",
+            "biomesoplenty:brushland",
+            "biomesoplenty:grove",
+            "biomesoplenty:land_of_lakes",
+            "biomesoplenty:lush_swamp",
+            "biomesoplenty:mountain",
+            "biomesoplenty:orchard",
+            "biomesoplenty:overgrown_cliffs",
+            "biomesoplenty:seasonal_forest",
+            "biomesoplenty:temperate_rainforest",
+            "biomesoplenty:wetland",
+            "biomesoplenty:woodland",
+            "biomesoplenty:mountain_foothills"
+    };
+
+    private static String[] defaultCold = new String[]{
+            // TEMPERATURE CATEGORY COLD
+            "minecraft:taiga_cold",
+            "minecraft:taiga_cold_hills",
+            "minecraft:mutated_taiga_cold",
+            "biomesoplenty:snowy_coniferous_forest",
+            "biomesoplenty:snowy_forest",
+            "biomesoplenty:alps_foothills",
+            // TEMPERATURE CATEGORY MEDIUM: 0.2 ... 0.45
+            "minecraft:taiga",
+            "minecraft:taiga_hills",
+            "biomesoplenty:boreal_forest",
+            "biomesoplenty:coniferous_forest",
+            "biomesoplenty:maple_woods",
+            "biomesoplenty:seasonal_forest",
+    };
+
+    public List<Biome> availableBiomes;
+    public List<TreeGenerationConfiguration> treeConfigurations = new ArrayList<>();
+    public boolean enableFruitTreeGeneration;
+    private Configuration config;
+
+    private int fruitGrowthSpeed;
+
+    public int getFruitGrowthSpeed() {
+        return fruitGrowthSpeed;
+    }
+
+    public FruitTreeConfigManager(Configuration config) {
+        this.config = config;
+    }
+
+    /**
+     * call Configure during init
+     * this allows to dynamically detect biomes and use the FruitRegistry
+     */
+    public void Configure() {
+        config.load();
+
+        ConfigureCommon();
+        ConfigureFruits();
+
+        if (config.hasChanged()) {
+            config.save();
+        }
+    }
+
+    private void ConfigureCommon() {
+        availableBiomes = ForgeRegistries.BIOMES.getValues();
+        StringBuilder biomeNames = new StringBuilder();
+        biomeNames.append("Available/Detected biomes: ");
+        for (Biome x : this.availableBiomes) {
+            biomeNames.append("[" + x.getRegistryName().toString() + "], ");
+            FMLLog.log.info(
+                    x.getRegistryName().toString() + ";" +
+                            x.getBiomeName() + ";" +
+                            x.getTempCategory() + ";" +
+                            x.getTemperature() + ";" +
+                            x.isHighHumidity() + ";" +
+                            x.isMutation() + ";" +
+                            x.isSnowyBiome() + ";" +
+                            BiomeDictionary.getTypes(x).toString()
+            );
+
+        }
+
+        this.config.setCategoryComment(CATEGORY_FRUIT_TREES_COMMON, biomeNames.toString());
+
+        this.enableFruitTreeGeneration = config.get(CATEGORY_FRUIT_TREES_COMMON, "enableFruitTreeGeneration", true, "Default: true").getBoolean();
+        this.fruitGrowthSpeed = config.get(CATEGORY_FRUIT_TREES_COMMON, "fruitGrowthSpeed", 25, "Default: 25, Lower is faster").getInt();
+    }
+
+    private void configureForFruit(String fruit, BlockPamSapling.SaplingType saplingType) {
+        boolean enable = this.config.getBoolean("enableGeneration", fruit, true, "");
+        int rarity = this.config.getInt("rarity", fruit, 20, 0, 100, "rarity range 0 ... 100, where 0 is common and 100 is rare");
+
+        String[] biomesAllowed = new String[]{};
+        if (saplingType == BlockPamSapling.SaplingType.TEMPERATE) {
+            biomesAllowed = config.getStringList(WHITELIST, fruit, defaultTemperate, "temperate");
+        } else if (saplingType == BlockPamSapling.SaplingType.COLD) {
+            biomesAllowed = config.getStringList(WHITELIST, fruit, defaultCold, "cold");
+        } else if (saplingType == BlockPamSapling.SaplingType.WARM) {
+            biomesAllowed = config.getStringList(WHITELIST, fruit, defaultWarm, "warm");
+        }
+
+        TreeGenerationConfiguration treeGenerationConfiguration = new TreeGenerationConfiguration(fruit, enable, rarity, availableBiomes, biomesAllowed);
+        treeConfigurations.add(treeGenerationConfiguration);
+    }
+
+    private void ConfigureFruits() {
+        HashMap<String, BlockPamSapling.SaplingType> availableFruits = FruitRegistry.registeringFruits;
+        availableFruits.putAll(FruitRegistry.registeringLogFruits);
+
+        availableFruits.forEach(this::configureForFruit);
+    }
+
+    public List<TreeGenerationConfiguration> getFruitTreesInBiome(Biome biome) {
+        List<TreeGenerationConfiguration> list = new ArrayList<>();
+        for (TreeGenerationConfiguration tc : treeConfigurations) {
+            if (tc.getEnableGeneration() && tc.getBiomesAllowed().contains(biome)) {
+                list.add(tc);
+            }
+        }
+        return list;
+    }
+
+    public List<TreeGenerationConfiguration> getFruitTreesInBiomeWithLowerRarity(int rarity, Biome biome) {
+        List<TreeGenerationConfiguration> list = new ArrayList<>();
+        for (TreeGenerationConfiguration tc : treeConfigurations) {
+            if (tc.getEnableGeneration()
+                    && tc.getRarity() < rarity
+                    && tc.getBiomesAllowed().contains(biome)) {
+                list.add(tc);
+            }
+        }
+        return list;
+    }
+}

--- a/src/main/java/com/pam/harvestcraft/config/TreeGenerationConfiguration.java
+++ b/src/main/java/com/pam/harvestcraft/config/TreeGenerationConfiguration.java
@@ -1,0 +1,52 @@
+package com.pam.harvestcraft.config;
+
+import net.minecraft.world.biome.Biome;
+import net.minecraftforge.fml.common.FMLLog;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+public class TreeGenerationConfiguration {
+    private String fruit;
+    private boolean enableGeneration = true;
+    private int rarity = 20;
+    private List<Biome> biomesAllowed = new ArrayList<>();
+
+    public TreeGenerationConfiguration(String fruit, boolean enableGeneration, int rarity, List<Biome> availableBiomes, String[] biomesAllowed) {
+        this.fruit = fruit;
+        this.enableGeneration = enableGeneration;
+        if (!this.enableGeneration) {
+            FMLLog.log.trace("generation is disabled for " + fruit);
+            return;
+        }
+        this.rarity = rarity;
+
+        Arrays.stream(biomesAllowed).forEach((item) -> {
+            Optional<Biome> found = availableBiomes.stream().filter(b -> b.getRegistryName().toString().equalsIgnoreCase(item)).findFirst();
+            if (found != null
+                    && found.isPresent()
+                    && !this.getBiomesAllowed().contains(found.get())) {
+                FMLLog.log.trace("biome added:" + found.get().getRegistryName().toString());
+                this.biomesAllowed.add(found.get());
+            }
+        });
+    }
+
+    public boolean getEnableGeneration() {
+        return this.enableGeneration;
+    }
+
+    public String getFruit() {
+        return fruit;
+    }
+
+    public int getRarity() {
+        return rarity;
+    }
+
+    public List<Biome> getBiomesAllowed() {
+        return biomesAllowed;
+    }
+}

--- a/src/main/java/com/pam/harvestcraft/worldgen/FruitTreeWorldGen.java
+++ b/src/main/java/com/pam/harvestcraft/worldgen/FruitTreeWorldGen.java
@@ -1,242 +1,59 @@
 package com.pam.harvestcraft.worldgen;
 
-import static com.pam.harvestcraft.HarvestCraft.config;
+import static com.pam.harvestcraft.HarvestCraft.fruitTreeConfigManager;
 
+import java.util.List;
 import java.util.Random;
 
 import com.pam.harvestcraft.blocks.FruitRegistry;
 import com.pam.harvestcraft.blocks.growables.BlockPamSapling;
 
+import com.pam.harvestcraft.config.TreeGenerationConfiguration;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.chunk.IChunkProvider;
-import net.minecraftforge.common.BiomeDictionary;
+
+import net.minecraftforge.fml.common.FMLLog;
 import net.minecraftforge.fml.common.IWorldGenerator;
 
 public class FruitTreeWorldGen implements IWorldGenerator {
 
     @Override
     public void generate(Random random, int chunkX, int chunkZ, World world,
-			net.minecraft.world.gen.IChunkGenerator chunkGenerator, IChunkProvider chunkProvider) {
-        if (random.nextFloat() > 0.12f) {
+                         net.minecraft.world.gen.IChunkGenerator chunkGenerator, IChunkProvider chunkProvider) {
+        if (!fruitTreeConfigManager.enableFruitTreeGeneration) {
+            FMLLog.log.debug("disabled fruit tree generation");
             return;
         }
 
         final int x = chunkX * 16 + 8 + random.nextInt(16);
         final int z = chunkZ * 16 + 8 + random.nextInt(16);
 
-        final Biome biome = world.getBiomeForCoordsBody(new BlockPos(x, 64, z));
+        Biome biome = world.getBiomeForCoordsBody(new BlockPos(x, 64, z));
 
-        if (BiomeDictionary.hasType(biome, BiomeDictionary.Type.DEAD)) {
+        int rarity = random.nextInt(100);
+        List<TreeGenerationConfiguration> fruitTreesRarity = fruitTreeConfigManager.getFruitTreesInBiomeWithLowerRarity(rarity, biome);
+
+        if (fruitTreesRarity.isEmpty()) {
+            FMLLog.log.debug("no fruit available for biome: " + biome.getRegistryName().toString() + " with rarity < " + rarity + ".");
+            return;
+        }
+        int index = random.nextInt(fruitTreesRarity.size());
+        if (index < 0) {
+            FMLLog.log.debug("is < 0");
+            return;
+        }
+        TreeGenerationConfiguration fruitTree = fruitTreesRarity.get(index);
+
+        if (fruitTree == null) {
+            FMLLog.log.debug("fruit tree is null");
             return;
         }
 
-        if ((BiomeDictionary.hasType(biome, BiomeDictionary.Type.FOREST))
-                && (!BiomeDictionary.hasType(biome, BiomeDictionary.Type.COLD))
-                && (!BiomeDictionary.hasType(biome, BiomeDictionary.Type.SPOOKY))
-                && (!BiomeDictionary.hasType(biome, BiomeDictionary.Type.MOUNTAIN))) {
-            {
-                switch (random.nextInt(10)) {
-                    case 0:
-                        if (config.appletreeGeneration) {
-                            generateFruitTree(world, random, FruitRegistry.APPLE, x, z);
-                            return;
-                        }
-                    case 1:
-                        if (config.avocadotreeGeneration) {
-                            generateFruitTree(world, random, FruitRegistry.AVOCADO, x, z);
-                            return;
-                        }
-                    case 2:
-                        if (config.cherrytreeGeneration) {
-                            generateFruitTree(world, random, FruitRegistry.CHERRY, x, z);
-                            return;
-                        }
-                    case 3:
-                        if (config.chestnuttreeGeneration) {
-                            generateFruitTree(world, random, FruitRegistry.CHESTNUT, x, z);
-                            return;
-                        }
-                    case 4:
-                        if (config.nutmegtreeGeneration) {
-                            generateFruitTree(world, random, FruitRegistry.NUTMEG, x, z);
-                            return;
-                        }
-                    case 5:
-                        if (config.peartreeGeneration) {
-                            generateFruitTree(world, random, FruitRegistry.PEAR, x, z);
-                            return;
-                        }
-                    case 6:
-                        if (config.plumtreeGeneration) {
-                            generateFruitTree(world, random, FruitRegistry.PLUM, x, z);
-                            return;
-                        }
-                    case 7:
-                        if (config.walnuttreeGeneration) {
-                            generateFruitTree(world, random, FruitRegistry.WALNUT, x, z);
-                            return;
-                        }
-                    case 8:
-                        if (config.gooseberrytreeGeneration) {
-                            generateFruitTree(world, random, FruitRegistry.GOOSEBERRY, x, z);
-                            return;
-                        }
-                    case 9:
-                        if (config.spiderwebtreeGeneration) {
-                            generateFruitTree(world, random, FruitRegistry.SPIDERWEB, x, z);
-                            return;
-                        }
-                }
-            }
-        }
-
-        if ( (!BiomeDictionary.hasType(biome, BiomeDictionary.Type.PLAINS)) && (!BiomeDictionary.hasType(biome, BiomeDictionary.Type.DRY))
-        && ( BiomeDictionary.hasType(biome, BiomeDictionary.Type.HOT) || (BiomeDictionary.hasType(biome, BiomeDictionary.Type.WET)) ) ) {
-            switch (random.nextInt(25)) {
-                case 0:
-                    if (config.bananatreeGeneration) {
-                        generateFruitTree(world, random, FruitRegistry.BANANA, x, z);
-                        return;
-                    }
-                case 1:
-                    if (config.cinnamontreeGeneration) {
-                        generateFruitTree(world, random, FruitRegistry.CINNAMON, x, z);
-                        return;
-                    }
-                case 2:
-                    if (config.coconuttreeGeneration) {
-                        generateFruitTree(world, random, FruitRegistry.COCONUT, x, z);
-                        return;
-                    }
-                case 3:
-                    if (config.datetreeGeneration) {
-                        generateFruitTree(world, random, FruitRegistry.DATE, x, z);
-                        return;
-                    }
-                case 4:
-                    if (config.dragonfruittreeGeneration) {
-                        generateFruitTree(world, random, FruitRegistry.DRAGONFRUIT, x, z);
-                        return;
-                    }
-                case 5:
-                    if (config.papayatreeGeneration) {
-                        generateFruitTree(world, random, FruitRegistry.PAPAYA, x, z);
-                        return;
-                    }
-                case 6:
-                    if (config.almondtreeGeneration) {
-                        generateFruitTree(world, random, FruitRegistry.ALMOND, x, z);
-                        return;
-                    }
-                case 7:
-                    if (config.apricottreeGeneration) {
-                        generateFruitTree(world, random, FruitRegistry.APRICOT, x, z);
-                        return;
-                    }
-                case 8:
-                    if (config.cashewtreeGeneration) {
-                        generateFruitTree(world, random, FruitRegistry.CASHEW, x, z);
-                        return;
-                    }
-                case 9:
-                    if (config.duriantreeGeneration) {
-                        generateFruitTree(world, random, FruitRegistry.DURIAN, x, z);
-                        return;
-                    }
-                case 10:
-                    if (config.figtreeGeneration) {
-                        generateFruitTree(world, random, FruitRegistry.FIG, x, z);
-                        return;
-                    }
-                case 11:
-                    if (config.grapefruittreeGeneration) {
-                        generateFruitTree(world, random, FruitRegistry.GRAPEFRUIT, x, z);
-                        return;
-                    }
-                case 12:
-                    if (config.lemontreeGeneration) {
-                        generateFruitTree(world, random, FruitRegistry.LEMON, x, z);
-                        return;
-                    }
-                case 13:
-                    if (config.limetreeGeneration) {
-                        generateFruitTree(world, random, FruitRegistry.LIME, x, z);
-                        return;
-                    }
-                case 14:
-                    if (config.mangotreeGeneration) {
-                        generateFruitTree(world, random, FruitRegistry.MANGO, x, z);
-                        return;
-                    }
-                case 15:
-                    if (config.orangetreeGeneration) {
-                        generateFruitTree(world, random, FruitRegistry.ORANGE, x, z);
-                        return;
-                    }
-                case 16:
-                    if (config.paperbarktreeGeneration) {
-                        generateFruitTree(world, random, FruitRegistry.PAPERBARK, x, z);
-                        return;
-                    }
-                case 17:
-                    if (config.peachtreeGeneration) {
-                        generateFruitTree(world, random, FruitRegistry.PEACH, x, z);
-                        return;
-                    }
-                case 18:
-                    if (config.pecantreeGeneration) {
-                        generateFruitTree(world, random, FruitRegistry.PECAN, x, z);
-                        return;
-                    }
-                case 19:
-                    if (config.peppercorntreeGeneration) {
-                        generateFruitTree(world, random, FruitRegistry.PEPPERCORN, x, z);
-                        return;
-                    }
-                case 20:
-                    if (config.persimmontreeGeneration) {
-                        generateFruitTree(world, random, FruitRegistry.PERSIMMON, x, z);
-                        return;
-                    }
-                case 21:
-                    if (config.pistachiotreeGeneration) {
-                        generateFruitTree(world, random, FruitRegistry.PISTACHIO, x, z);
-                        return;
-                    }
-                case 22:
-                    if (config.pomegranatetreeGeneration) {
-                        generateFruitTree(world, random, FruitRegistry.POMEGRANATE, x, z);
-                        return;
-                    }
-                case 23:
-                    if (config.starfruittreeGeneration) {
-                        generateFruitTree(world, random, FruitRegistry.STARFRUIT, x, z);
-                        return;
-                    }
-                case 24:
-                    if (config.vanillabeantreeGeneration) {
-                        generateFruitTree(world, random, FruitRegistry.VANILLABEAN, x, z);
-                        return;
-                    }
-                case 25:
-                    if (config.olivetreeGeneration) {
-                        generateFruitTree(world, random, FruitRegistry.OLIVE, x, z);
-                        return;
-                    }
-            }
-        }
-
-        if ((BiomeDictionary.hasType(biome, BiomeDictionary.Type.SNOWY))
-                || (BiomeDictionary.hasType(biome, BiomeDictionary.Type.MOUNTAIN))
-                || (BiomeDictionary.hasType(biome, BiomeDictionary.Type.CONIFEROUS))) {
-            if (config.mapletreeGeneration) {
-                generateFruitTree(world, random, FruitRegistry.MAPLE, x, z);
-                return;
-            }
-        }
-
+//        FMLLog.log.debug("generate tree:" + fruitTree.getFruit());
+        generateFruitTree(world, random, fruitTree.getFruit(), x, z);
+        return;
     }
 
     private void generateFruitTree(World world, Random random, String fruitName, int x, int z) {


### PR DESCRIPTION
* moved fruittree configuration from ConfigHandler to FruitTreeConfigManager etc. => allows later loading of the fruittree config (during init)
* fruittree configuration now uses its own config file
* Use FruitRegistry for dynamically generating the configuration
* Changed rarity of fruittrees: common 0 ... 100 rare
* Use only whitelisted biomes (every fruit can be configured)
* Detect available biomes (written as comment in the config file, to allow easy configuration)
* handpicked some biomes from minecraft and biomesoplenty for the default whitelists: cold, temperate and warm saplings

Closes #83, Closes #65