### PR TITLE
Right click harvesting cancels block placement

### DIFF
--- a/src/main/java/com/pam/harvestcraft/addons/RightClickHarvesting.java
+++ b/src/main/java/com/pam/harvestcraft/addons/RightClickHarvesting.java
@@ -21,6 +21,7 @@ import net.minecraft.init.Enchantments;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumHand;
+import net.minecraft.util.EnumActionResult;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.common.MinecraftForge;
@@ -43,10 +44,6 @@ public class RightClickHarvesting {
 		if(!HarvestCraft.config.enableEasyHarvest)
 			return;
 
-		if(event.getWorld().isRemote) {
-			return;
-		}
-
 		if(event.getEntityPlayer() == null)
 			return;
 		if(event.getHand() != EnumHand.MAIN_HAND)
@@ -55,15 +52,21 @@ public class RightClickHarvesting {
 		final IBlockState blockState = event.getWorld().getBlockState(event.getPos());
 
 		if(blockState.getBlock() instanceof BlockCrops) {
-			harvestCrops(blockState, event.getEntityPlayer(), event.getWorld(), event.getPos());
+			if(!event.getWorld().isRemote) harvestCrops(blockState, event.getEntityPlayer(), event.getWorld(), event.getPos());
+			event.setCancellationResult(EnumActionResult.SUCCESS);
+			event.setCanceled(true);
 		}
 
-		if(blockState.getBlock() instanceof BlockNetherWart) {
-			harvestNetherWart(blockState, event.getEntityPlayer(), event.getWorld(), event.getPos());
+		else if(blockState.getBlock() instanceof BlockNetherWart) {
+			if(!event.getWorld().isRemote) harvestNetherWart(blockState, event.getEntityPlayer(), event.getWorld(), event.getPos());
+			event.setCancellationResult(EnumActionResult.SUCCESS);
+			event.setCanceled(true);
 		}
 
-		if(blockState.getBlock() instanceof BlockPamFruit || blockState.getBlock() instanceof BlockPamFruitLog) {
-			harvestFruit(blockState, event.getEntityPlayer(), event.getWorld(), event.getPos());
+		else if(blockState.getBlock() instanceof BlockPamFruit || blockState.getBlock() instanceof BlockPamFruitLog) {
+			if(!event.getWorld().isRemote) harvestFruit(blockState, event.getEntityPlayer(), event.getWorld(), event.getPos());
+			event.setCancellationResult(EnumActionResult.SUCCESS);
+			event.setCanceled(true);
 		}
 	}
 

--- a/src/main/java/com/pam/harvestcraft/addons/RightClickHarvesting.java
+++ b/src/main/java/com/pam/harvestcraft/addons/RightClickHarvesting.java
@@ -27,6 +27,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.ForgeEventFactory;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+import net.minecraftforge.fml.common.eventhandler.Event;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
 public class RightClickHarvesting {
@@ -46,27 +47,40 @@ public class RightClickHarvesting {
 
 		if(event.getEntityPlayer() == null)
 			return;
-		if(event.getHand() != EnumHand.MAIN_HAND)
-			return;
 
 		final IBlockState blockState = event.getWorld().getBlockState(event.getPos());
 
 		if(blockState.getBlock() instanceof BlockCrops) {
-			if(!event.getWorld().isRemote) harvestCrops(blockState, event.getEntityPlayer(), event.getWorld(), event.getPos());
-			event.setCancellationResult(EnumActionResult.SUCCESS);
-			event.setCanceled(true);
+			// we harvest with mainhand only
+			// but we cancel both hands
+			if(event.getHand() == EnumHand.MAIN_HAND) {
+				if(!event.getWorld().isRemote)
+					// must be run by server only
+					harvestCrops(blockState, event.getEntityPlayer(), event.getWorld(), event.getPos());
+				event.getEntityPlayer().swingArm(EnumHand.MAIN_HAND);
+			}
+			// this actually denies block placement only
+			// targeted block and held item can still be activated
+			event.setUseItem(Event.Result.DENY);
 		}
 
+		// now do this again for other block types
 		else if(blockState.getBlock() instanceof BlockNetherWart) {
-			if(!event.getWorld().isRemote) harvestNetherWart(blockState, event.getEntityPlayer(), event.getWorld(), event.getPos());
-			event.setCancellationResult(EnumActionResult.SUCCESS);
-			event.setCanceled(true);
+			if(event.getHand() == EnumHand.MAIN_HAND) {
+				if(!event.getWorld().isRemote)
+					harvestNetherWart(blockState, event.getEntityPlayer(), event.getWorld(), event.getPos());
+				event.getEntityPlayer().swingArm(EnumHand.MAIN_HAND);
+			}
+			event.setUseItem(Event.Result.DENY);
 		}
 
 		else if(blockState.getBlock() instanceof BlockPamFruit || blockState.getBlock() instanceof BlockPamFruitLog) {
-			if(!event.getWorld().isRemote) harvestFruit(blockState, event.getEntityPlayer(), event.getWorld(), event.getPos());
-			event.setCancellationResult(EnumActionResult.SUCCESS);
-			event.setCanceled(true);
+			if(event.getHand() == EnumHand.MAIN_HAND) {
+				if(!event.getWorld().isRemote)
+					harvestFruit(blockState, event.getEntityPlayer(), event.getWorld(), event.getPos());
+				event.getEntityPlayer().swingArm(EnumHand.MAIN_HAND);
+			}
+			event.setUseItem(Event.Result.DENY);
 		}
 	}
 


### PR DESCRIPTION
You may want to check this out. Placing dirt or torches while right clicking crops and fruits will not be a concern anymore.