### PR TITLE
Fix itemGroup not showing when using the en_us.lang file

### DIFF
--- a/src/main/resources/assets/harvestcraft/lang/en_us.lang
+++ b/src/main/resources/assets/harvestcraft/lang/en_us.lang
@@ -1,4 +1,4 @@
-﻿itemGroup.harvestcraft=HarvestCraft
+itemGroup.harvestcraft=HarvestCraft
 
 # Blocks
 harvestcraft.harvestcraft.tile.cuttingboard.name=Cutting Board


### PR DESCRIPTION
Changed encoding from UTF-8-BOM to UTF-8 to remove characters added by
the BOM version.