### PR TITLE
Updated the Gradle wrapper to 4.2

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.2-bin.zip


### PR DESCRIPTION
This pull request updates the version of Gradle from 2.14 to 4.2. There are a lot of differences between these versions, but the main changes important for modding is that a LOT of optimizations have been made. To help demonstrate this, I ran two benchmarks of `gradlew build` with your project, on the two versions. 

Gradle 2.14: 3 minutes 20 seconds
Gradle 4.2: 2 minutes 7 seconds. 

Over all this change improved the timing by 1 minute and 13 seconds. These optimizations extend to all of the gradle commands that you would use, and should make it much quicker for you to get stuff done. 