### PR TITLE
Added configuration for enabling or disabling Wheat as an edible item

### DIFF
--- a/src/main/java/com/pam/harvestcraft/config/ConfigHandler.java
+++ b/src/main/java/com/pam/harvestcraft/config/ConfigHandler.java
@@ -33,6 +33,7 @@ public class ConfigHandler {
     private static final String CATEGORY_MISC_RECIPES = "miscellaneous recipes";
     private static final String CATEGORY_SHIPPINGBIN_PURCHASES = "shipping bin purchases";
     private static final String CATEGORY_SHIPPINGBIN_PRICES = "shipping bin prices";
+    private static final String CATEGORY_FOOD = "food items";
     //public static final String CATEGORY_WHITELIST = "whitelist";
 
     /**
@@ -99,6 +100,10 @@ public class ConfigHandler {
     private final Map<String, String[]> gardenDropConfig = new HashMap<String, String[]>();
 
 
+    // Food items config
+    public static boolean makeWheatEdible;
+    
+    
     // Block configuration variables
     public int gardenRarity;
     public int gardendropAmount;
@@ -202,12 +207,14 @@ public class ConfigHandler {
         config.load();
 
         initGeneralSettings();
+        initFoodSettings();
         initCropSettings();
         initSeedDropSettings();
         initGardenSettings();
         initMarketSettings();
         initBeesSettings();
         initMiscRecipesSettings();
+        
 
         if (config.hasChanged()) {
             config.save();
@@ -219,6 +226,10 @@ public class ConfigHandler {
         beehiveRarity = config.getInt("beehiveRarity", CATEGORY_BEE, 10, 0, Short.MAX_VALUE, "The higher the value, the more beehives are generated.");
         queenbeelastresultequalsQueen = config.getBoolean("apiarylastresultequalsQueen", CATEGORY_BEE, true, "If true, the last item produced by a queen bee will be another queen bee.");
         enablebeegrubaslistAllmeat  = config.getBoolean("enablebeegrubaslistAllmeat", CATEGORY_BEE, true, "Allows grubs and cooked grubs to be used in listAllrawmeat and listAllcookedmeat.");
+    }
+    
+    private void initFoodSettings() {
+    	makeWheatEdible = config.getBoolean("makeWheatEdible", CATEGORY_FOOD, true, "Enables Wheat as an edible item");
     }
 
     private void initGeneralSettings() {

--- a/src/main/java/com/pam/harvestcraft/item/ItemRegistry.java
+++ b/src/main/java/com/pam/harvestcraft/item/ItemRegistry.java
@@ -1053,7 +1053,9 @@ public final class ItemRegistry {
 
 	private static void registerVanillaReplacementItems() {
 		harvestappleItem = registerItemFood("minecraft:apple", config.cropfoodRestore, config.cropsaturationRestore);
-		harvestwheatItem = registerItemFood("minecraft:wheat", config.cropfoodRestore, config.cropsaturationRestore);
+		if (ConfigHandler.makeWheatEdible == true) {
+			harvestwheatItem = registerItemFood("minecraft:wheat", config.cropfoodRestore, config.cropsaturationRestore);
+		}
 		harvestpotatoItem = registerItemSeedFood("minecraft:potato", config.cropfoodRestore, config.cropsaturationRestore, Blocks.POTATOES, Blocks.FARMLAND);
 		harvestcarrotItem = registerItemSeedFood("minecraft:carrot", config.cropfoodRestore, config.cropsaturationRestore, Blocks.CARROTS, Blocks.FARMLAND);
 		harvestbeetItem = registerItemFood("minecraft:beetroot", config.cropfoodRestore, config.cropsaturationRestore);


### PR DESCRIPTION
Hi, i had an issue with this mod that made Wheat edible and so the cows and sheeps wouldn't follow me or breed. Since i saw that there was at least one more person facing this same issue i forked your repo and added a new configuration option to set it whether you want the mod to make wheat edible or not. You just have to set it in the configuration file (it's default value is true so it will still make wheat edible by default but it will let the user decide if they want to disable it as edible).

I hope you can add this modification to your main repo and make a little release or snapshot including this so other people with the same issue can get it solved.

Thanks.-