### PR TITLE
Allow planting a sapling on anything plantable, including BoP dirt

### DIFF
--- a/src/main/java/com/pam/harvestcraft/blocks/growables/BlockPamSapling.java
+++ b/src/main/java/com/pam/harvestcraft/blocks/growables/BlockPamSapling.java
@@ -15,12 +15,14 @@ import net.minecraft.block.BlockLeaves;
 import net.minecraft.block.BlockOldLeaf;
 import net.minecraft.block.BlockOldLog;
 import net.minecraft.block.BlockPlanks;
+import net.minecraft.block.BlockSapling;
 import net.minecraft.block.IGrowable;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.Item;
 import net.minecraft.util.BlockRenderLayer;
+import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
@@ -80,9 +82,11 @@ public class BlockPamSapling extends BlockBush implements IGrowable {
 
     @Override
     public boolean canPlaceBlockAt(World world, BlockPos pos) {
-        Block soilBlock = world.getBlockState(pos.down()).getBlock();
+        BlockPos down = pos.down();
+        IBlockState soilBlockState = world.getBlockState(down);
+        Block soilBlock = soilBlockState.getBlock();
 
-        return this.isSuitableSoilBlock(soilBlock);
+        return soilBlock.canSustainPlant(soilBlockState, world, down, EnumFacing.UP, (BlockSapling) Blocks.SAPLING);
     }
 
     public void neighborChanged(IBlockState state, World worldIn, BlockPos pos, Block blockIn) {
@@ -105,10 +109,6 @@ public class BlockPamSapling extends BlockBush implements IGrowable {
     @Override
     public boolean isFullCube(IBlockState state) {
         return false;
-    }
-
-    private boolean isSuitableSoilBlock(Block soilBlock) {
-        return soilBlock == Blocks.GRASS || soilBlock == Blocks.DIRT || soilBlock == Blocks.FARMLAND;
     }
 
     @Override


### PR DESCRIPTION
I found the `canSustainPlant` method is used in several other places for this purpose. Update the sapling to use the same logic. Now Pam's saplings can be planted on BoP grass.

Tested this with forge version `1.12.2-14.23.5.2781` and `BiomesOPlenty-1.12.2-7.0.1.2424`. I was able to plant a pam's Apple Sapling on silty grass and grow it with bone meal.

![image](https://user-images.githubusercontent.com/196978/50809614-46adcd80-12ca-11e9-8d0f-7a6e8d8e8598.png)


This fixes #272 .