### PR TITLE
Draws default background in Machine Gui

### DIFF
--- a/src/main/java/com/pam/harvestcraft/gui/GuiApiary.java
+++ b/src/main/java/com/pam/harvestcraft/gui/GuiApiary.java
@@ -33,6 +33,7 @@ public class GuiApiary extends GuiContainer {
     
     @Override
     public void drawScreen(int mouseX, int mouseY, float partialTicks) {
+        drawDefaultBackground();
         super.drawScreen(mouseX, mouseY, partialTicks);
         renderHoveredToolTip(mouseX, mouseY);
     }

--- a/src/main/java/com/pam/harvestcraft/gui/GuiGrinder.java
+++ b/src/main/java/com/pam/harvestcraft/gui/GuiGrinder.java
@@ -32,6 +32,7 @@ public class GuiGrinder extends GuiContainer {
     
     @Override
     public void drawScreen(int mouseX, int mouseY, float partialTicks) {
+        drawDefaultBackground();
         super.drawScreen(mouseX, mouseY, partialTicks);
         renderHoveredToolTip(mouseX, mouseY);
     }

--- a/src/main/java/com/pam/harvestcraft/gui/GuiGroundTrap.java
+++ b/src/main/java/com/pam/harvestcraft/gui/GuiGroundTrap.java
@@ -33,6 +33,7 @@ public class GuiGroundTrap extends GuiContainer {
     
     @Override
     public void drawScreen(int mouseX, int mouseY, float partialTicks) {
+        drawDefaultBackground();
         super.drawScreen(mouseX, mouseY, partialTicks);
         renderHoveredToolTip(mouseX, mouseY);
     }

--- a/src/main/java/com/pam/harvestcraft/gui/GuiMarket.java
+++ b/src/main/java/com/pam/harvestcraft/gui/GuiMarket.java
@@ -141,6 +141,7 @@ public class GuiMarket extends GuiContainer {
 	}
 
 	public void drawScreen(int par1, int par2, float par3) {
+		drawDefaultBackground();
 		super.drawScreen(par1, par2, par3);
 		ItemStack item = MarketItems.getData(itemNum).getItem();
 

--- a/src/main/java/com/pam/harvestcraft/gui/GuiPresser.java
+++ b/src/main/java/com/pam/harvestcraft/gui/GuiPresser.java
@@ -33,6 +33,7 @@ public class GuiPresser extends GuiContainer {
     
     @Override
     public void drawScreen(int mouseX, int mouseY, float partialTicks) {
+        drawDefaultBackground();
         super.drawScreen(mouseX, mouseY, partialTicks);
         renderHoveredToolTip(mouseX, mouseY);
     }

--- a/src/main/java/com/pam/harvestcraft/gui/GuiShippingBin.java
+++ b/src/main/java/com/pam/harvestcraft/gui/GuiShippingBin.java
@@ -146,6 +146,7 @@ public class GuiShippingBin extends GuiContainer {
 	}
 
 	public void drawScreen(int par1, int par2, float par3) {
+		drawDefaultBackground();
 		super.drawScreen(par1, par2, par3);
 		ItemStack item = ShippingBinItems.getData(itemNum).getItem();
 

--- a/src/main/java/com/pam/harvestcraft/gui/GuiWaterFilter.java
+++ b/src/main/java/com/pam/harvestcraft/gui/GuiWaterFilter.java
@@ -32,6 +32,7 @@ public class GuiWaterFilter extends GuiContainer {
     
     @Override
     public void drawScreen(int mouseX, int mouseY, float partialTicks) {
+        drawDefaultBackground();
         super.drawScreen(mouseX, mouseY, partialTicks);
         renderHoveredToolTip(mouseX, mouseY);
     }

--- a/src/main/java/com/pam/harvestcraft/gui/GuiWaterTrap.java
+++ b/src/main/java/com/pam/harvestcraft/gui/GuiWaterTrap.java
@@ -33,6 +33,7 @@ public class GuiWaterTrap extends GuiContainer {
     
     @Override
     public void drawScreen(int mouseX, int mouseY, float partialTicks) {
+        drawDefaultBackground();
         super.drawScreen(mouseX, mouseY, partialTicks);
         renderHoveredToolTip(mouseX, mouseY);
     }


### PR DESCRIPTION
Append `drawDefaultBackground()` in `GuiScreen` (as it draws a grey background by default) so that machine gui are more recognizable in screen.

Tested with no problems.