### PR TITLE
Update en_us.lang

### DIFF
--- a/src/main/resources/assets/harvestcraft/lang/en_us.lang
+++ b/src/main/resources/assets/harvestcraft/lang/en_us.lang
@@ -1,4 +1,4 @@
-﻿itemGroup.harvestcraft=HarvestCraft
+itemGroup.harvestcraft=HarvestCraft
 
 
 harvestcraft.harvestcraft.tile.cuttingboard.name=Cutting Board


### PR DESCRIPTION
Makes the Creative tab name display in game rather than be broken.