### PR TITLE
Fix malformed JSON for Cucumber Sandwich and Cassoulet

### DIFF
--- a/src/main/resources/assets/harvestcraft/recipes/cassouletitem.json
+++ b/src/main/resources/assets/harvestcraft/recipes/cassouletitem.json
@@ -8,35 +8,35 @@
       "type": "forge:ore_dict",
       "ore": "toolPot"
     },
-{
+    {
       "type": "forge:ore_dict",
       "ore": "listAllduckraw"
     },
-{
+    {
       "type": "forge:ore_dict",
       "ore": "foodSausage"
     },
-{
+    {
       "type": "forge:ore_dict",
       "ore": "listAllporkraw"
     },
-{
+    {
       "type": "forge:ore_dict",
       "ore": "cropBean"
     },
-{
+    {
       "type": "forge:ore_dict",
-      "ore": cropOnion"
+      "ore": "cropOnion"
     },
-{
+    {
       "type": "forge:ore_dict",
       "ore": "cropSpiceleaf"
     },
-{
+    {
       "type": "forge:ore_dict",
       "ore": "cropGarlic"
     },
-{
+    {
       "type": "forge:ore_dict",
       "ore": "cropCarrot"
     }

--- a/src/main/resources/assets/harvestcraft/recipes/cucumbersandwichitem.json
+++ b/src/main/resources/assets/harvestcraft/recipes/cucumbersandwichitem.json
@@ -8,19 +8,18 @@
       "type": "forge:ore_dict",
       "ore": "toolCuttingboard"
     },
-,
-{
+    {
       "item": "minecraft:bread"
-    }
-{
+    },
+    {
       "type": "forge:ore_dict",
       "ore": "cropCucumber"
     },
-{
+    {
       "type": "forge:ore_dict",
       "ore": "foodCheese"
     },
-{
+    {
       "type": "forge:ore_dict",
       "ore": "listAllheavycream"
     }


### PR DESCRIPTION
Recipes for [Cucumber Sandwich](https://jsonlint.com/?json=https://raw.githubusercontent.com/MatrexsVigil/harvestcraft/2819cf88ebabbb0964535579eac8332d036143ed/src/main/resources/assets/harvestcraft/recipes/cucumbersandwichitem.json) and [Cassoulet](https://jsonlint.com/?json=https://raw.githubusercontent.com/MatrexsVigil/harvestcraft/2819cf88ebabbb0964535579eac8332d036143ed/src/main/resources/assets/harvestcraft/recipes/cassouletitem.json) are malformed, as reported in #331. This PR fixes both.