### PR TITLE
match output from freshmilkitem for freshwateritem

### DIFF
--- a/src/main/resources/assets/harvestcraft/recipes/freshwateritem_minecraft_water_bucket.json
+++ b/src/main/resources/assets/harvestcraft/recipes/freshwateritem_minecraft_water_bucket.json
@@ -1,7 +1,7 @@
 {
   "result": {
     "item": "harvestcraft:freshwateritem",
-    "count": 1
+    "count": 4
   },
   "group":"harvestcraft_freshwateritem",
   "ingredients": [


### PR DESCRIPTION
freshmilkitem (https://github.com/MatrexsVigil/harvestcraft/blob/master/src/main/resources/assets/harvestcraft/recipes/freshmilkitem_minecraft_milk_bucket.json#L4) has a 1 / 4 ratio, and I don't see much reason to nerf freshwater specifically.

@dammitdiane