### PR TITLE
Shipping Bin Fix

### DIFF
--- a/src/main/java/com/pam/harvestcraft/gui/ContainerShippingBin.java
+++ b/src/main/java/com/pam/harvestcraft/gui/ContainerShippingBin.java
@@ -66,6 +66,17 @@ public class ContainerShippingBin extends Container {
 			if (marketData.getCurrency().isItemEqual(emeralds) && marketData.getPrice() <= emeralds.getCount()) {
 				emeralds.shrink(marketData.getPrice());
 				return marketData.getItem().copy();
+			} 
+			else if(!marketData.getCurrency().isItemEqual(emeralds)) {
+				for(int i = 1; i < ShippingBinItems.getSize(); i++) {
+					int index = (item+i)%ShippingBinItems.getSize();
+					marketData = ShippingBinItems.getData(index);
+					if (marketData.getCurrency().isItemEqual(emeralds) && marketData.getPrice() <= emeralds.getCount()) {
+						bin.setBrowsingInfo(index);
+						emeralds.shrink(marketData.getPrice());
+						return marketData.getItem().copy();
+					} 
+				}
 			}
 		}
 		return ItemStack.EMPTY;

--- a/src/main/java/com/pam/harvestcraft/gui/ContainerShippingBin.java
+++ b/src/main/java/com/pam/harvestcraft/gui/ContainerShippingBin.java
@@ -20,7 +20,7 @@ public class ContainerShippingBin extends Container {
 	public ContainerShippingBin(IInventory par1IInventory, TileEntityShippingBin tileEntity) {
 		bin = tileEntity;
 
-		addSlotToContainer(new SlotItemHandler(new ItemStackHandler(), 0, 113, 38));
+		addSlotToContainer(new SlotPamShippingBin(new ItemStackHandler(), 0, 113, 38));
 
 		for(int i = 0; i < 3; i++) {
 			for(int j = 0; j < 9; j++) {

--- a/src/main/java/com/pam/harvestcraft/gui/SlotPamShippingBin.java
+++ b/src/main/java/com/pam/harvestcraft/gui/SlotPamShippingBin.java
@@ -1,0 +1,30 @@
+package com.pam.harvestcraft.gui;
+
+import com.pam.harvestcraft.tileentities.ShippingBinItems;
+
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.items.IItemHandler;
+import net.minecraftforge.items.SlotItemHandler;
+
+public class SlotPamShippingBin extends SlotItemHandler {
+	
+	public SlotPamShippingBin(IItemHandler handler, int index, int xPos, int yPos) {
+		super(handler, index, xPos, yPos);
+		
+	}
+
+	@Override
+	public int getSlotStackLimit() {
+		return 64;
+	}
+
+	@Override
+	public boolean isItemValid(ItemStack stack) {
+		for(int i = 0; i < ShippingBinItems.getSize(); i++) {
+			if(ShippingBinItems.getData(i).getCurrency().isItemEqual(stack)) {
+				return true;
+			}
+		}
+		return false;
+	}
+}


### PR DESCRIPTION
#347 

Right now to sell items in the shipping bin, players must scroll through the list of all sellable items one by one. I have fixed this by selling to the player regardless of if they have found the correct item or not.

I have also made a custom Slot class for the bin that only accepts valid items.